### PR TITLE
Updated propsal related queries to make them more efficient

### DIFF
--- a/src/store/assignments/actions.js
+++ b/src/store/assignments/actions.js
@@ -22,6 +22,7 @@ export const loadProposals = async function ({ commit }, { first, offset }) {
           contents {
             label
             value
+            type
           }
         }
         original{
@@ -32,6 +33,7 @@ export const loadProposals = async function ({ commit }, { first, offset }) {
             contents {
               label
               value
+              type
             }
           }
         }
@@ -43,6 +45,7 @@ export const loadProposals = async function ({ commit }, { first, offset }) {
             contents {
               label
               value
+              type
             }
           }
         }
@@ -54,6 +57,7 @@ export const loadProposals = async function ({ commit }, { first, offset }) {
             contents {
               label
               value
+              type
             }
           }
         }
@@ -65,6 +69,7 @@ export const loadProposals = async function ({ commit }, { first, offset }) {
             contents {
               label
               value
+              type
             }
           }
         }

--- a/src/store/assignments/actions.js
+++ b/src/store/assignments/actions.js
@@ -2,27 +2,74 @@ import Turndown from 'turndown'
 
 export const loadProposals = async function ({ commit }, { first, offset }) {
   const query = `
-  query proposals($first:int, $offset: int) {
-    var(func: has(proposal)) {
-      proposals as proposal @cascade{
+    query proposals($first:int, $offset: int) {
+      var(func: has(proposal)) {
+        proposals as proposal @cascade{
+          content_groups {
+            contents  @filter(eq(label,"type") and (eq(value, "assignment") or eq(value, "edit") or eq(value, "suspend"))){
+              label
+              value
+            }
+          }
+        }
+      }
+      proposals(func: uid(proposals), orderdesc:created_date, first: $first, offset: $offset) {
+        uid
+        hash
+        creator
+        created_date
         content_groups {
-          contents  @filter(eq(label,"type") and (eq(value, "assignment") or eq(value, "edit") or eq(value, "suspend"))){
+          contents {
             label
             value
           }
         }
-      }
-    }
-    proposals(func: uid(proposals), orderdesc:created_date, first: $first, offset: $offset) {
-      expand(_all_) {
-        expand(_all_) {
-          expand(_all_) {
-            expand(_all_)
+        original{
+          hash
+          creator
+          created_date
+          content_groups {
+            contents {
+              label
+              value
+            }
+          }
+        }
+        suspend{
+          hash
+          creator
+          created_date
+          content_groups {
+            contents {
+              label
+              value
+            }
+          }
+        }
+        votetally{
+          hash
+          creator
+          created_date
+          content_groups {
+            contents {
+              label
+              value
+            }
+          }
+        }
+        vote {
+          hash
+          creator
+          created_date
+          content_groups {
+            contents {
+              label
+              value
+            }
           }
         }
       }
     }
-  }
   `
   const result = await this.$dgraph.newTxn().queryWithVars(query, { $first: '' + first, $offset: '' + offset })
   commit('addProposals', result.data.proposals)

--- a/src/store/badges/actions.js
+++ b/src/store/badges/actions.js
@@ -85,6 +85,7 @@ export const loadBadgeAssignmentProposals = async function ({ commit }, { first,
           contents {
             label
             value
+            type
           }
         }
         votetally{
@@ -95,6 +96,7 @@ export const loadBadgeAssignmentProposals = async function ({ commit }, { first,
             contents {
               label
               value
+              type
             }
           }
         }
@@ -106,6 +108,7 @@ export const loadBadgeAssignmentProposals = async function ({ commit }, { first,
             contents {
               label
               value
+              type
             }
           }
         }

--- a/src/store/badges/actions.js
+++ b/src/store/badges/actions.js
@@ -65,27 +65,52 @@ export const loadProposals = async function ({ commit }, { first, offset }) {
 
 export const loadBadgeAssignmentProposals = async function ({ commit }, { first, offset }) {
   const query = `
-  query proposals($first:int, $offset: int) {
-    var(func: has(proposal)) {
-      proposals as proposal @cascade{
+    query proposals($first:int, $offset: int) {
+      var(func: has(proposal)) {
+        proposals as proposal @cascade{
+          content_groups {
+            contents  @filter(eq(label,"type") and eq(value, "assignbadge")){
+              label
+              value
+            }
+          }
+        }
+      }
+      proposals(func: uid(proposals), orderdesc:created_date, first: $first, offset: $offset) {
+        uid
+        hash
+        creator
+        created_date
         content_groups {
-          contents  @filter(eq(label,"type") and eq(value, "assignbadge")){
+          contents {
             label
             value
           }
         }
-      }
-    }
-    proposals(func: uid(proposals), orderdesc:created_date, first: $first, offset: $offset) {
-      expand(_all_) {
-        expand(_all_) {
-          expand(_all_) {
-            expand(_all_)
+        votetally{
+          hash
+          creator
+          created_date
+          content_groups {
+            contents {
+              label
+              value
+            }
+          }
+        }
+        vote {
+          hash
+          creator
+          created_date
+          content_groups {
+            contents {
+              label
+              value
+            }
           }
         }
       }
     }
-  }
   `
   const result = await this.$dgraph.newTxn().queryWithVars(query, { $first: '' + first, $offset: '' + offset })
   commit('addProposals', result.data.proposals)

--- a/src/store/payouts/actions.js
+++ b/src/store/payouts/actions.js
@@ -53,6 +53,7 @@ export const loadProposals = async function ({ commit }, { first, offset }) {
           contents {
             label
             value
+            type
           }
         }
         votetally{
@@ -63,6 +64,7 @@ export const loadProposals = async function ({ commit }, { first, offset }) {
             contents {
               label
               value
+              type
             }
           }
         }
@@ -74,6 +76,7 @@ export const loadProposals = async function ({ commit }, { first, offset }) {
             contents {
               label
               value
+              type
             }
           }
         }

--- a/src/store/payouts/actions.js
+++ b/src/store/payouts/actions.js
@@ -32,28 +32,53 @@ export const savePayoutProposal = async function ({ rootState }, draft) {
 
 export const loadProposals = async function ({ commit }, { first, offset }) {
   const query = `
-  query proposals($first:int, $offset: int) {
-    var(func: has(proposal)) {
-      proposals as proposal @cascade{
+    query proposals($first:int, $offset: int) {
+      var(func: has(proposal)) {
+        proposals as proposal @cascade{
+          created_date
+          content_groups {
+            contents  @filter(eq(label,"type") and eq(value, "payout")){
+              label
+              value
+            }
+          }
+        }
+      }
+      proposals(func: uid(proposals), orderdesc:created_date, first: $first, offset: $offset) {
+        uid
+        hash
+        creator
         created_date
         content_groups {
-          contents  @filter(eq(label,"type") and eq(value, "payout")){
+          contents {
             label
             value
           }
         }
-      }
-    }
-    proposals(func: uid(proposals), orderdesc:created_date, first: $first, offset: $offset) {
-      expand(_all_) {
-        expand(_all_) {
-          expand(_all_) {
-            expand(_all_)
+        votetally{
+          hash
+          creator
+          created_date
+          content_groups {
+            contents {
+              label
+              value
+            }
+          }
+        }
+        vote {
+          hash
+          creator
+          created_date
+          content_groups {
+            contents {
+              label
+              value
+            }
           }
         }
       }
     }
-  }
   `
   const result = await this.$dgraph.newTxn().queryWithVars(query, { $first: '' + first, $offset: '' + offset })
   commit('addProposals', result.data.proposals)


### PR DESCRIPTION
Updated propsal related queries to make them more efficient, by eliminating expand all instructions and retrieving only the required data