### PR TITLE
Add voting percentages to fix an error with unity and quorum

### DIFF
--- a/src/store/dao/getters.js
+++ b/src/store/dao/getters.js
@@ -13,3 +13,7 @@ export const getDaoTokens = (state) => ({
   voiceToken: state.settings.voiceToken,
   voiceTokenDecimals: state.settings.voiceTokenDecimals
 })
+export const votingPercentages = ({ settings }) => ({
+  quorum: settings.votingQuorumPercent,
+  unity: settings.votingAlignmentPercent
+})


### PR DESCRIPTION
- Add a new getter on dao store to get the unity and quorum values