### PR TITLE
Blank space removed

### DIFF
--- a/src/pages/proposals/ProposalList.vue
+++ b/src/pages/proposals/ProposalList.vue
@@ -377,7 +377,7 @@ export default {
     .col-9
       base-placeholder.q-mr-sm(v-if="!filteredProposals.length && !filteredStagedProposals.length && !$apollo.loading" title= "No Proposals" subtitle="Your organization has not created any proposals yet. You can create a new proposal by clicking the button below."
         icon= "fas fa-file-medical" :actionButtons="[{label: 'Create a new Proposal', color: 'primary', onClick: () => $router.push(`/${this.daoSettings.url}/proposals/create`), disable: !isMember, disableTooltip: 'You must be a member'}]" )
-      .q-mb-xl(v-show="showStagedProposals")
+      .q-mb-xl(v-show="showStagedProposals && filteredStagedProposals.length > 0")
         proposal-list(:username="account" :proposals="filteredStagedProposals" :supply="supply" :view="view")
       q-infinite-scroll(@load="onLoad" :offset="500" ref="scroll" :initial-index="1" v-if="filteredProposals.length").scroll
         proposal-list(:username="account" :proposals="filteredProposals" :supply="supply" :view="view")


### PR DESCRIPTION
Now in the proposal screen, the "Show staging proposals" toggle doesn't leave a blank space when there is nothing to show