### PR TITLE
Proposal Card showing undefined user in some cases fixed

### DIFF
--- a/src/query/proposals/dao-proposals-stage.gql
+++ b/src/query/proposals/dao-proposals-stage.gql
@@ -101,7 +101,8 @@ query stageProposals($docId: String!, $first: Int!, $offset: Int!) {
         details_ballotSupply_a
         details_ballotAlignment_i
         details_minTimeShareX100_i
-        details_owner_n
+        details_owner_n,
+        creator
       }
 
       ... on Badge {


### PR DESCRIPTION
Staging Proposals of type "Role Archetype" no longer shows undefined in the user field.