### PR TITLE
Header and commitment fixed in proposal detail widget

### DIFF
--- a/src/components/profiles/proposal-item.vue
+++ b/src/components/profiles/proposal-item.vue
@@ -24,6 +24,10 @@ export default {
       type: String,
       default: 'grey-3'
     },
+    clickable: {
+      type: Boolean,
+      default: true
+    },
     proposal: undefined,
     expandable: Boolean,
     owner: Boolean,
@@ -535,7 +539,7 @@ export default {
 </script>
 
 <template lang="pug">
-widget(noPadding :background="background" :class="{ 'cursor-pointer': owner || proposed }" @click.native="(owner || proposed) && onClick()").q-px-sm
+widget(noPadding :background="background" :class="{ 'cursor-pointer': (owner || proposed) && clickable }" @click.native="(owner || proposed) && onClick()").q-px-sm
   .flex.justify-center(:class="{item: !expandable, 'item-expandable': expandable}")
     contribution-header.q-px-lg(
       v-if="contribution"

--- a/src/components/proposals/proposal-view.vue
+++ b/src/components/proposals/proposal-view.vue
@@ -188,7 +188,7 @@ widget.proposal-view.q-mb-sm
         .col-6(v-if="commit !== undefined")
           .text-bold Commitment level
           .text-grey-7.text-body2 {{ (newCommit !== undefined ? newCommit : commit.value) + '%' }}
-            .text-secondary.text-body2.q-ml-xxs.inline(v-if="ownAssignment && (newCommit ? newCommit : commit.value) !== commit.max") {{(newCommit ? newCommit : commit.value) - commit.max + '%' }}
+            .text-secondary.text-body2.q-ml-xxs.inline(v-if="ownAssignment && newCommit !== undefined && (newCommit ? newCommit : commit.value) !== commit.max") {{(newCommit ? newCommit : commit.value) - commit.max + '%' }}
             .dynamic-popup(v-if="showCommitPopup")
               proposal-dynamic-popup(
                 title="Adjust Commitment"

--- a/src/pages/proposals/ProposalDetail.vue
+++ b/src/pages/proposals/ProposalDetail.vue
@@ -738,9 +738,7 @@ export default {
       }
       if (proposal.details_timeShareX100_i) {
         return {
-          value: proposal.details_timeShareX100_i,
-          min: 0,
-          max: 0
+          value: proposal.details_timeShareX100_i
         }
       }
       return undefined
@@ -829,6 +827,7 @@ export default {
       proposal-item.bottom-no-rounded(
         v-if="ownAssignment"
         background="white"
+        :clickable="false",
         :proposal="proposal"
         :expandable="true"
         :owner="true"


### PR DESCRIPTION
Now the header is no longer using the "hand" mouse pointer, the dinamic commitment is no longer appearing if the user didn't change it at least once.