### PR TITLE
Default logo now shows up correctly

### DIFF
--- a/src/components/ipfs/ipfs-image-viewer.vue
+++ b/src/components/ipfs/ipfs-image-viewer.vue
@@ -55,8 +55,12 @@ export default {
   },
 
   computed: {
-    label () { return this.defaultLabel ? this.defaultLabel.slice(0, 2).toUpperCase() : '' }
-
+    label () {
+      return this.defaultLabel ? this.defaultLabel.slice(0, 2).toUpperCase() : ''
+    },
+    fontSize () {
+      return this.size * 0.8
+    }
   },
   watch: {
     ipfsCid (cid) {
@@ -75,7 +79,5 @@ export default {
         :color="textColor"
         v-else-if="!imageURI && isLoading"
     )
-    slot(name="def" v-else-if="!imageURI && !isLoading && showDefault")
-      span {{ this.label }}
-        //- q-icon(name="fas fa-edit" v-else-if="!imageURI && !isUploading" size="sm" color="primary")
+    span(v-else-if="!imageURI && !isLoading && showDefault" size=size font-size=fontSize color="primary" text-color="white") {{ this.label }}
 </template>

--- a/src/components/navigation/dho-btn.vue
+++ b/src/components/navigation/dho-btn.vue
@@ -21,7 +21,7 @@ export default {
   .q-ma-sm.no-pointer-events(v-if="disable")
   q-btn.q-ma-sm(v-else round @click="$emit('click')")
     q-avatar(size="48px" font-size="24px" color="primary" text-color="white")
-      span(v-show="!logo") {{ title && title[0] }}
+      span(v-show="!logo") {{ title && `${title[0]}${title[1]}` }}
       img(v-show="logo" :src="ipfsy(logo)")
     q-tooltip(
       v-if="!disable"

--- a/src/components/navigation/dho-card.vue
+++ b/src/components/navigation/dho-card.vue
@@ -92,7 +92,7 @@ q-card.dho-card(flat).flex.column.items-center.justify-between
     div.cursor-pointer(@click="goToDaoInNewTab")
       ipfs-image-viewer(
         :ipfsCid="logo"
-        showDefault
+        :showDefault = "true"
         :defaultLabel="name"
         :size="height/1.5 + 'px'"
       )

--- a/src/components/profiles/organizations.vue
+++ b/src/components/profiles/organizations.vue
@@ -21,8 +21,10 @@ export default {
   methods: {
     onSeeMore () {
       this.$emit('onSeeMore')
+    },
+    label (name) {
+      return name.slice(0, 2).toUpperCase()
     }
-
   }
 }
 </script>
@@ -33,8 +35,10 @@ widget(title="Organizations")
     template(v-for="(organisation, index) in organizations")
       q-item(:key="index" :class="index===0 && 'q-mt-md'" ripple="false" :to="'/' + organisation.url ").list-item.q-py-md.q-px-none.cursor-pointer.row.justify-center.items-center
         q-item-section(avatar)
-          q-avatar(size="xl")
+          q-avatar(v-if = "organisation.logo" size="xl")
             img(:src="organisation.logo")
+          q-avatar(v-else size="xl" color="primary" text-color="white" font-size='24px') {{ label(organisation.name) }}
+
         q-item-section.text-body1.text-bold.creator(lines="1" :title="organisation.name") {{ truncate(organisation.name, 15) }}
         q-btn(round unelevated icon="fas fa-chevron-right" color="inherit" text-color="disabled" size="sm" :ripple="false" )
   .q-pt-md.flex.flex-center(v-if="true")


### PR DESCRIPTION
- The left side dao explorer now shows the first two letters of the name instead of just one.

- The organization widget now shows the default logo when there is not an image to load.