### PR TITLE
Removed acl setting flag from the S3 sync job of the staging github w…

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -51,7 +51,7 @@ jobs:
       - name: S3 sync
         uses: jakejarvis/s3-sync-action@master
         with:
-          args: --acl public-read --follow-symlinks --delete
+          args: --follow-symlinks --delete
         env:
           AWS_S3_BUCKET: ${{ secrets.STAGING_AWS_S3_BUCKET }}
           AWS_ACCESS_KEY_ID: ${{ secrets.STAGING_AWS_ACCESS_KEY_ID }}


### PR DESCRIPTION
Removed acl setting flag from the S3 sync job of the staging github workflow, that was causing a permission denied issue