### PR TITLE
Profile button is now always active

### DIFF
--- a/src/components/navigation/quick-links.vue
+++ b/src/components/navigation/quick-links.vue
@@ -53,7 +53,7 @@ export default {
           q-icon.q-pa-xs(size="md" name="fas fa-file-medical")
           .text-caption.text-no-wrap.text-bold New Proposal
     .col-6(:class="{ 'col-12': compact }")
-      q-btn.button-square(@click="changeRoute('profile', {username})" rounded unelevated :color="isActiveRoute('profile') && isUserProfile ? 'primary' : 'internal-bg'" :text-color="isActiveRoute('profile') && isUserProfile ? 'internal-bg' : 'primary'" :disabled="!isMember")
+      q-btn.button-square(@click="changeRoute('profile', {username})" rounded unelevated color = 'primary' text-color = 'internal-bg')
         .column.items-center
           q-icon.q-pa-xs( size="md" name="far fa-user")
           .text-caption.text-no-wrap.text-bold My Profile


### PR DESCRIPTION
In the profile sidebar, the quick-links component now shows the profile button as active all the time, regardless of the DAO the user is in.

### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

#1385

### ✅ Checklist

- [X] The profile button is now active even if the user is not member of the DAO he/she is exploring.
