### PR TITLE
Fixed proposal detail page when there are no comments with reactions

### DIFF
--- a/src/components/proposals/comment-item.vue
+++ b/src/components/proposals/comment-item.vue
@@ -19,8 +19,8 @@ export default {
     },
 
     author: {
-      type: Object,
-      default: () => {}
+      type: String,
+      default: undefined
     },
 
     content: {
@@ -28,7 +28,7 @@ export default {
     },
 
     createdDate: {
-      type: Date
+      type: String
     },
 
     commentAggregate: {
@@ -75,9 +75,9 @@ export default {
   },
 
   computed: {
-    hasMore () { return this.commentAggregate.count > 0 },
+    hasMore () { return this.commentAggregate?.count > 0 },
 
-    hasLiked () { return this.reactions ? this.reactions.users.includes(this.author) : false },
+    hasLiked () { return this.reactions ? this.reactions.users?.includes(this.author) : false },
 
     numberOfLikes () { return this.reactions ? this.reactions.count : 0 },
 

--- a/src/pages/proposals/ProposalDetail.vue
+++ b/src/pages/proposals/ProposalDetail.vue
@@ -85,8 +85,8 @@ export default {
       const mapComment = comment => ({
         ...comment,
         reactions: {
-          count: comment.reactions[0].reactionlnkrAggregate.count,
-          users: comment.reactions[0].reactionlnkr.map(_ => _.author)
+          count: comment.reactions[0]?.reactionlnkrAggregate?.count,
+          users: comment.reactions[0]?.reactionlnkr?.map(_ => _.author)
         }
       })
 
@@ -142,7 +142,7 @@ export default {
   watch: {
 
     proposal () {
-      this.proposal.cmntsect[0].comment.forEach(comment => {
+      this.proposal.cmntsect[0]?.comment.forEach(comment => {
         this.$set(this.commentByIds, comment.id, comment)
         if (this.rootCommentIds.includes(comment.id)) return
         this.rootCommentIds.push(comment.id)


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)
Fixed a bug that prevented loading of the details page when there were no comments with reactions on the proposal.

### ✅ Checklist

- [x ] Github issue details are up to date for people to QA.
- [x ] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

### 🙈 Screenshots

### 👯‍♀️ Paired with

