### PR TITLE
fix (proposals): title and description error messages restored

### DIFF
--- a/src/components/common/input-editor.vue
+++ b/src/components/common/input-editor.vue
@@ -5,6 +5,10 @@ export default {
     rules: {
       type: Array,
       default: () => {}
+    },
+    color: {
+      type: String,
+      default: 'heading'
     }
   }
 }
@@ -12,7 +16,7 @@ export default {
 
 <template lang = "pug">
 q-editor(:content-style="{ color: '#84878E', fontWeight: 'normal' }"
-         color = "heading"
+         :color = "color"
          :rules = "rules"
          v-bind = "{...$attrs, ...$props, ...$slots}"
          v-on = "$listeners")

--- a/src/components/common/input-field.vue
+++ b/src/components/common/input-field.vue
@@ -5,14 +5,18 @@ export default {
     rules: {
       type: Array,
       default: () => {}
+    },
+    color: {
+      type: String,
+      default: 'heading'
     }
   }
 }
 </script>
 
 <template lang="pug">
-q-input(color = "heading"
-        ref="input"
+q-input(ref="input"
+        :color = "color"
         :rules = "rules"
         v-bind = "{...$attrs, ...$props, ...$slots}"
         v-on = "$listeners")

--- a/src/mixins/validation.js
+++ b/src/mixins/validation.js
@@ -11,6 +11,7 @@ export const validation = {
         accountFormat: val => /^([a-z]|[1-5]|.){1,12}$/.test(val.toLowerCase()) || 'The account must contain lowercase characters only, number from 1 to 5 or a period.',
         accountFormatBasic: val => /^([a-z]|[1-5]){12}$/.test(val.toLowerCase()) || 'The account must contain lowercase characters only and number from 1 to 5.',
         accountLength: val => val.length === 12 || 'The account must contain 12 characters',
+        newProposalTitleLength: val => val.length >= 50 || `Proposal title length has to be less or equal to 50 characters (your title contain ${val.length} characters)`,
         maxLength: val => value => value.length <= val || `This field must contain less than ${val} characters`,
         isAccountAvailable: async account => (await this.isAccountFree(account.toLowerCase())) || `The account "${account}" already exists`,
         accountExists: async account => !(await this.isAccountFree(account.toLowerCase())) || `The account "${account}" doesn't exist`,

--- a/src/mixins/validation.js
+++ b/src/mixins/validation.js
@@ -11,7 +11,6 @@ export const validation = {
         accountFormat: val => /^([a-z]|[1-5]|.){1,12}$/.test(val.toLowerCase()) || 'The account must contain lowercase characters only, number from 1 to 5 or a period.',
         accountFormatBasic: val => /^([a-z]|[1-5]){12}$/.test(val.toLowerCase()) || 'The account must contain lowercase characters only and number from 1 to 5.',
         accountLength: val => val.length === 12 || 'The account must contain 12 characters',
-        newProposalTitleLength: val => val.length >= 50 || `Proposal title length has to be less or equal to 50 characters (your title contain ${val.length} characters)`,
         maxLength: val => value => value.length <= val || `This field must contain less than ${val} characters`,
         isAccountAvailable: async account => (await this.isAccountFree(account.toLowerCase())) || `The account "${account}" already exists`,
         accountExists: async account => !(await this.isAccountFree(account.toLowerCase())) || `The account "${account}" doesn't exist`,

--- a/src/pages/proposals/create/StepDescription.vue
+++ b/src/pages/proposals/create/StepDescription.vue
@@ -112,13 +112,13 @@ widget
       label.h-label {{ fields.title.label }}
       input-field.q-mt-xs.rounded-border(
         :placeholder="fields.title.placeholder"
+        :color="title.length >= 50 ? 'negative' : 'heading'"
         :rules="[val => !!val || 'Title is required', rules.maxLength(50)]"
         dense
         lazy-rules="ondemand"
         outlined
         v-model="title"
       )
-
     .col(v-if="fields.badgeRestriction")
       label.h-label {{ fields.badgeRestriction.label }}
       q-icon.q-ml-xxs(size="1rem" name="fas fa-info-circle")
@@ -130,7 +130,7 @@ widget
         lazy-rules="ondemand"
         v-model="badgeRestriction"
       )
-
+  .col.text-negative.h-b2.q-ml-xs(v-if="title.length >= 50") Proposal title length has to be less or equal to 50 characters (your title contain {{title.length}} characters).
   .col(v-if="fields.description").q-mt-md
     label.h-label {{ fields.description.label }}
         q-field.full-width.q-mt-xs.rounded-border(
@@ -141,7 +141,7 @@ widget
           outlined
           ref="bio"
           stack-label
-          color = "heading"
+          :color="description.length >= 2000 ? 'negative' : 'heading'"
           v-model="description"
         )
           input-editor.full-width(

--- a/src/pages/proposals/create/StepDescription.vue
+++ b/src/pages/proposals/create/StepDescription.vue
@@ -145,7 +145,6 @@ widget
           outlined
           ref="bio"
           stack-label
-          :color="description.length >= 2000 ? 'negative' : 'heading'"
           v-model="description"
         )
           input-editor.full-width(

--- a/src/pages/proposals/create/StepDescription.vue
+++ b/src/pages/proposals/create/StepDescription.vue
@@ -2,6 +2,9 @@
 import { validation } from '~/mixins/validation'
 // import { isURL } from 'validator'
 
+const TITLE_MAX_LENGTH = 50
+const DESCRIPTION_MAX_LENGTH = 50
+
 export default {
   name: 'step-description',
   mixins: [validation],
@@ -12,14 +15,19 @@ export default {
     InputField: () => import('~/components/common/input-field.vue'),
     InputEditor: () => import('~/components/common/input-editor.vue')
   },
-
+  data () {
+    return {
+      TITLE_MAX_LENGTH: TITLE_MAX_LENGTH,
+      DESCRIPTION_MAX_LENGTH: DESCRIPTION_MAX_LENGTH
+    }
+  },
   props: {
     fields: Object
   },
 
   computed: {
     nextDisabled () {
-      if (this.title.length > 0 && this.description.length <= 2000) {
+      if (this.title.length > 0 && this.description.length < DESCRIPTION_MAX_LENGTH && this.title.length <= TITLE_MAX_LENGTH) {
         // if (this.url && isURL(this.url, { require_protocol: true })) {
         //   return false
         // }
@@ -112,10 +120,8 @@ widget
       label.h-label {{ fields.title.label }}
       input-field.q-mt-xs.rounded-border(
         :placeholder="fields.title.placeholder"
-        :color="title.length >= 50 ? 'negative' : 'heading'"
-        :rules="[val => !!val || 'Title is required', rules.maxLength(50)]"
+        :rules="[val => !!val || 'Title is required', val => (val.length <= TITLE_MAX_LENGTH) || `Proposal title length has to be less or equal to ${TITLE_MAX_LENGTH} characters (your title contain ${title.length} characters)`]"
         dense
-        lazy-rules="ondemand"
         outlined
         v-model="title"
       )
@@ -130,13 +136,11 @@ widget
         lazy-rules="ondemand"
         v-model="badgeRestriction"
       )
-  .col.text-negative.h-b2.q-ml-xs(v-if="title.length >= 50") Proposal title length has to be less or equal to 50 characters (your title contain {{title.length}} characters).
   .col(v-if="fields.description").q-mt-md
     label.h-label {{ fields.description.label }}
         q-field.full-width.q-mt-xs.rounded-border(
-          :rules="[rules.required]"
+          :rules="[rules.required, val => val.length < DESCRIPTION_MAX_LENGTH || `The description must contain less than ${DESCRIPTION_MAX_LENGTH} characters (your description contain ${description.length} characters)`]"
           dense
-          lazy-rules="ondemand"
           maxlength="2000"
           outlined
           ref="bio"
@@ -152,7 +156,6 @@ widget
             ref="editorRef"
             v-model="description"
           )
-    .text-negative.h-b2.q-ml-xs(v-if="description.length >= 2000") The description must contain less than 2,000 characters (your description contain {{description.length}} characters)
 
   .col(v-if="fields.url").q-mt-md
     label.h-label {{ fields.url.label }}


### PR DESCRIPTION
Now when the maximum amount of characters is surpased, the border color changes to red and the error message get displayed correctly.