### PR TITLE
fix: proposal description max length (#1496)

### DIFF
--- a/src/components/profiles/proposal-item.vue
+++ b/src/components/profiles/proposal-item.vue
@@ -243,6 +243,19 @@ widget(noPadding :background="background" :class="{ 'cursor-pointer': clickable 
       :compensation="compensation"
       :created="created"
     )
+      template(v-slot:right)
+        .q-mt-md(v-if="$q.screen.sm")
+        voting-result(v-if="isProposed" v-bind="voting" :colorConfig="isVotingExpired || isApproved ? expiredColorConfig : colorConfig" :colorConfigQuorum="isVotingExpired || isApproved ? expiredColorConfig : colorConfigQuorum")
+        q-btn.q-mr-md.view-proposa-btn(
+          v-if="!owner && !isProposed"
+          label="View proposal"
+          color="primary"
+          rounded
+          unelevated
+          no-caps
+          outline
+          @click="onClick"
+        )
     recurring-activity-header.q-px-lg(
       v-if="type === 'Assignment' || type === 'Assignbadge'"
       calendar

--- a/src/pages/proposals/create/StepDescription.vue
+++ b/src/pages/proposals/create/StepDescription.vue
@@ -3,7 +3,7 @@ import { validation } from '~/mixins/validation'
 // import { isURL } from 'validator'
 
 const TITLE_MAX_LENGTH = 50
-const DESCRIPTION_MAX_LENGTH = 50
+const DESCRIPTION_MAX_LENGTH = 2000
 
 export default {
   name: 'step-description',


### PR DESCRIPTION
* Title and description error messages restored

Now when the maximum amount of characters is surpased, the border color changes to red and the error message get displayed correctly.

* using rules for error messages

* Removed color override

* Updated description length

* Added missing view proposal button on profile

Co-authored-by: Funkalux <funkalux@gmail.com>

### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Enter Issue number here

### ✅ Checklist

- [ ] Github issue details are up to date for people to QA.
- [ ] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

_Technical explanations to help your peers review your work - including environments, credentials, etc._

### 🙈 Screenshots

_For all UI changes_

| description 1 | description 2 |
| --- | --- |
| img1 | img2 |

### 👯‍♀️ Paired with

_@github-handle or delete if you did not pair._
