### PR TITLE
fix: enable deferred button for archived assignments (#1489)

### DIFF
--- a/src/components/proposals/proposal-view.vue
+++ b/src/components/proposals/proposal-view.vue
@@ -224,7 +224,7 @@ widget.proposal-view.q-mb-sm
             flat round size="sm"
             icon="fas fa-pen"
             color="primary"
-            v-if="ownAssignment && status === 'approved'"
+            v-if="ownAssignment && status === 'approved' || 'archived'"
             @click="showDefferredPopup = true; showCommitPopup = false")
               q-tooltip Edit
     .col.bg-internal-bg.rounded-border.q-mr-xs(v-if="icon")


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Enable deferred button for archived assignments (#1489)

### ✅ Checklist

- [] Enabled deferred button for archived assignments

### 🕵️‍♂️ Notes for Code Reviewer

On the frontend side, one little thing was missing to display a button for archive assignments. I added this, but now I'm getting an error from the backend, I think @Gerard097 should enable this on the backend as well, I've seen a similar task https://github.com/hypha-dao/dao-contracts/issues/298 created for him.

### 🙈 Screenshots
![image](https://user-images.githubusercontent.com/18167258/187180243-e6123ec4-c015-4b50-8af5-73dd42a52d2e.png)
![image](https://user-images.githubusercontent.com/18167258/187180352-19a58941-fd86-477c-b028-5421ca6df805.png)

