### PR TITLE
fix: Hide Badge Multiplier (#1476)

### DIFF
--- a/src/components/common/token-value.vue
+++ b/src/components/common/token-value.vue
@@ -93,7 +93,7 @@ export default {
       .col
         .text-left.inline-block
           span(v-if="!coefficient") {{ getFormatedTokenAmount(value * multiplier, Number.MAX_VALUE) }}
-          span.text-bold.q-mx-sm(v-else-if="coefficient && (coefficientPercentage !== undefined || coefficientPercentage !== null )" :class="coefficientPercentage >= 0 ? 'text-positive' : 'text-negative'") x  {{ coefficientPercentage }}%
+          span.text-bold.q-mx-sm(v-else-if="coefficient && (coefficientPercentage !== undefined || coefficientPercentage !== null )" :class="coefficientPercentage >= 0 ? 'text-positive' : 'text-negative'") x  {{ coefficientPercentage }}
           q-tooltip(
             v-if="tooltip"
             anchor="top right"

--- a/src/pages/proposals/ProposalDetail.vue
+++ b/src/pages/proposals/ProposalDetail.vue
@@ -131,6 +131,10 @@ export default {
 
     periodsOnCycle () {
       return (this.cycleDurationSec / this.daoSettings.periodDurationSec).toFixed(2)
+    },
+
+    isDefaultBadgeMultiplier () {
+      return true
     }
   },
 
@@ -562,7 +566,7 @@ export default {
         :icon="proposalParsing.icon(proposal)"
         :commit="proposalParsing.commit(proposal)"
         :compensation="proposalParsing.compensation(proposal, daoSettings)"
-        :tokens="proposalParsing.tokens(proposal, periodsOnCycle, daoSettings)"
+        :tokens="proposalParsing.tokens(proposal, periodsOnCycle, daoSettings, isDefaultBadgeMultiplier)"
       )
       comments-widget(
         :comments="comments"

--- a/src/pages/proposals/create/StepReview.vue
+++ b/src/pages/proposals/create/StepReview.vue
@@ -144,7 +144,7 @@ export default {
       }
 
       if (this.fields.rewardCoefficient) {
-        const coefficientPercentage = this.$store.state.proposals.draft.rewardCoefficient.value / 10000
+        const coefficientPercentage = this.fields.rewardCoefficient.defaultValue ? 1 : this.$store.state.proposals.draft.rewardCoefficient.value / 10000
         tokens.push({
           label: `${this.fields.rewardCoefficient.label} (${this.$store.state.dao.settings.rewardToken})`,
           type: 'utility',
@@ -156,7 +156,7 @@ export default {
       }
 
       if (this.fields.pegCoefficient) {
-        const coefficientPercentage = this.$store.state.proposals.draft.pegCoefficient.value / 10000
+        const coefficientPercentage = this.fields.pegCoefficient.defaultValue ? 1 : this.$store.state.proposals.draft.pegCoefficient.value / 10000
         tokens.push({
           label: `${this.fields.pegCoefficient.label} (${this.$store.state.dao.settings.pegToken})`,
           type: 'cash',
@@ -167,7 +167,7 @@ export default {
         })
       }
       if (this.fields.voiceCoefficient) {
-        const coefficientPercentage = this.$store.state.proposals.draft.voiceCoefficient.value / 10000
+        const coefficientPercentage = this.fields.voiceCoefficient.defaultValue ? 1 : this.$store.state.proposals.draft.voiceCoefficient.value / 10000
         tokens.push({
           label: `${this.fields.voiceCoefficient.label} (${this.$store.state.dao.settings.voiceToken})`,
           type: 'voice',

--- a/src/pages/proposals/create/config.json
+++ b/src/pages/proposals/create/config.json
@@ -148,19 +148,22 @@
           "key": "voiceCoefficient",
           "label": "Voice Coefficient",
           "type": "percent",
-          "disabled": true
+          "disabled": true,
+          "defaultValue": true
         },
         "rewardCoefficient": {
           "key": "rewardCoefficient",
           "label": "Utility Coefficient",
           "type": "percent",
-          "disabled": true
+          "disabled": true,
+          "defaultValue": true
         },
         "pegCoefficient": {
           "key": "pegCoefficient",
           "label": "Cash Coefficient",
           "type": "percent",
-          "disabled": true
+          "disabled": true,
+          "defaultValue": true
         }
       }
     },
@@ -289,19 +292,22 @@
               "key": "voiceCoefficient",
               "label": "Voice Coefficient",
               "type": "percent",
-              "disabled": true
+              "disabled": true,
+              "defaultValue": true
             },
             "rewardCoefficient": {
               "key": "rewardCoefficient",
               "label": "Utility Coefficient",
               "type": "percent",
-              "disabled": true
+              "disabled": true,
+              "defaultValue": true
             },
             "pegCoefficient": {
               "key": "pegCoefficient",
               "label": "Cash Coefficient",
               "type": "percent",
-              "disabled": true
+              "disabled": true,
+              "defaultValue": true
             }
           }
         }
@@ -423,17 +429,20 @@
             "voiceCoefficient": {
               "key": "voiceCoefficient",
               "label": "Voice Coefficient",
-              "type": "percent"
+              "type": "percent",
+              "defaultValue": true
             },
             "rewardCoefficient": {
               "key": "rewardCoefficient",
               "label": "Utility Coefficient",
-              "type": "percent"
+              "type": "percent",
+              "defaultValue": true
             },
             "pegCoefficient": {
               "key": "pegCoefficient",
               "label": "Cash Coefficient",
-              "type": "percent"
+              "type": "percent",
+              "defaultValue": true
             }
           }
         }

--- a/src/pages/proposals/create/config.json
+++ b/src/pages/proposals/create/config.json
@@ -276,6 +276,9 @@
           "steps": {
             "icon": {
               "skip": true
+            },
+            "compensation": {
+              "skip": true
             }
           },
           "fields": {
@@ -400,6 +403,9 @@
           "description": "Share the details of this Badge by following the policies of this organization. Generally Badges need to define the Rights, Perks, and Powers that Badge holders receive. Remember, Badges belong to the organization, while Badge Assignments belong to you. If you don't know, ask an older member for help.",
           "steps": {
             "date": {
+              "skip": true
+            },
+            "compensation": {
               "skip": true
             }
           },

--- a/src/utils/proposal-parsing.js
+++ b/src/utils/proposal-parsing.js
@@ -474,7 +474,7 @@ export function start (proposal) {
   return null
 }
 
-export function tokens (proposal, periodsOnCycle, daoSettings) {
+export function tokens (proposal, periodsOnCycle, daoSettings, isDefaultBadgeMultiplier) {
   if (proposal.__typename === 'Suspend') proposal = proposal.suspend[0]
   if (proposal.__typename === 'Edit') proposal = proposal.original[0]
   if (proposal.__typename === 'Assignbadge') proposal = proposal.badge[0]
@@ -507,7 +507,7 @@ export function tokens (proposal, periodsOnCycle, daoSettings) {
           symbol: daoSettings.rewardToken,
           value: parseFloat(proposal.details_rewardCoefficientX10000_i / coefficientBase),
           coefficient: true,
-          coefficientPercentage: parseFloat(proposal.details_rewardCoefficientX10000_i / coefficientBase)
+          coefficientPercentage: isDefaultBadgeMultiplier ? 1 : parseFloat(proposal.details_rewardCoefficientX10000_i / coefficientBase)
         },
         {
           label: 'Cash Token Multiplier',
@@ -517,7 +517,7 @@ export function tokens (proposal, periodsOnCycle, daoSettings) {
           symbol: daoSettings.pegToken,
           value: parseFloat(proposal.details_pegCoefficientX10000_i / coefficientBase),
           coefficient: true,
-          coefficientPercentage: parseFloat(proposal.details_pegCoefficientX10000_i / coefficientBase)
+          coefficientPercentage: isDefaultBadgeMultiplier ? 1 : parseFloat(proposal.details_pegCoefficientX10000_i / coefficientBase)
         },
         {
           // label: `Voice Token Multiplier (${this.$store.state.dao.settings.voiceToken})`,
@@ -527,7 +527,7 @@ export function tokens (proposal, periodsOnCycle, daoSettings) {
           symbol: daoSettings.voiceToken,
           value: parseFloat(proposal.details_voiceCoefficientX10000_i) / coefficientBase,
           coefficient: true,
-          coefficientPercentage: parseFloat(proposal.details_voiceCoefficientX10000_i / coefficientBase)
+          coefficientPercentage: isDefaultBadgeMultiplier ? 1 : parseFloat(proposal.details_voiceCoefficientX10000_i / coefficientBase)
         }
       ]
     }


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Hide Badge Multiplier #1476

### ✅ Checklist

- Hide "Compensation" step for creating and extension badges
- Temporarily added a key to proposals config file to change multipliers to x1
- Added getter isDefaultBadgeMultiplier to display x1 in all assignments created for badges

### 🕵️‍♂️ Notes for Code Reviewer

Since now the multipliers do not work correctly (users receive the same rewards as x1 multipliers) and confuse users, I temporarily created several variables that change the display of all multipliers to x1, and also, at the request of @leonieherma1, hide one of the steps when expanding and creating a Badge assignment.

### 🙈 Screenshots

![image](https://user-images.githubusercontent.com/18167258/187212238-ae04611b-3589-4779-885a-2e339902c3e8.png)

