### PR TITLE
fix: remove character max from description (frontend) (#1555)

### DIFF
--- a/src/pages/proposals/create/StepDescription.vue
+++ b/src/pages/proposals/create/StepDescription.vue
@@ -28,7 +28,7 @@ export default {
 
   computed: {
     nextDisabled () {
-      if (this.title.length > 0 && this.description.length < DESCRIPTION_MAX_LENGTH && this.title.length <= TITLE_MAX_LENGTH) {
+      if (this.title.length > 0 && this.title.length <= TITLE_MAX_LENGTH) {
         // if (this.url && isURL(this.url, { require_protocol: true })) {
         //   return false
         // }
@@ -144,7 +144,6 @@ widget
   .col(v-if="fields.description").q-mt-md
     label.h-label {{ fields.description.label }}
         q-field.full-width.q-mt-xs.rounded-border(
-          :rules="[rules.required, val => val.length < DESCRIPTION_MAX_LENGTH || `The description must contain less than ${DESCRIPTION_MAX_LENGTH} characters (your description contain ${description.length} characters)`]"
           dense
           maxlength="2000"
           outlined


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

remove character max from description (frontend) (#1555)

### ✅ Checklist

- Warning about character max from description has been removed (#1555)

### 🕵️‍♂️ Notes for Code Reviewer

Removed the character limit in the description, but at the moment I'm getting an error from the backend. I think this also needs to be fixed.

