### PR TITLE
fix: current dao in left menu (dao switcher) has been hidden (#1544)

### DIFF
--- a/src/components/navigation/left-navigation.vue
+++ b/src/components/navigation/left-navigation.vue
@@ -74,7 +74,7 @@ export default {
           .column.dao-container(v-if="expanded")
             .row.full-width(v-for="dao in dhos")
               .full-width(:key="dao.name")
-                dho-btn(v-bind="dao" :logo="dao.icon" @click="switchDao(dao.url)")
+                dho-btn(v-if="dho.name != dao.name" v-bind="dao" :logo="dao.icon" @click="switchDao(dao.url)")
         .col-auto.q-my-sm.q-px-sm
           .full-width.border-bot
     .col-4.fixed-center#nav-buttons


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

DAO Switcher: don't show DAO I am currently in #1544

### ✅ Checklist

- Current DAO in left menu (dao switcher) has been hidden

### 🕵️‍♂️ Notes for Code Reviewer

Added a check to compare the name of the current DAO with those that are displayed in the list

### 🙈 Screenshots
![image](https://user-images.githubusercontent.com/18167258/188418218-fa192073-5cb8-4adb-90e2-42213732eb4f.png)

