### PR TITLE
fix: character max length in creating description for proposal has been fixed (#1555)

### DIFF
--- a/src/pages/proposals/create/StepDescription.vue
+++ b/src/pages/proposals/create/StepDescription.vue
@@ -4,7 +4,7 @@ import { validation } from '~/mixins/validation'
 import { toHTML, toMarkdown } from '~/utils/turndown'
 
 const TITLE_MAX_LENGTH = 50
-const DESCRIPTION_MAX_LENGTH = 2000
+const DESCRIPTION_MAX_LENGTH = 4000
 
 export default {
   name: 'step-description',
@@ -28,7 +28,7 @@ export default {
 
   computed: {
     nextDisabled () {
-      if (this.title.length > 0 && this.title.length <= TITLE_MAX_LENGTH) {
+      if (this.title.length > 0 && this.description.length < DESCRIPTION_MAX_LENGTH && this.title.length <= TITLE_MAX_LENGTH) {
         // if (this.url && isURL(this.url, { require_protocol: true })) {
         //   return false
         // }
@@ -144,6 +144,7 @@ widget
   .col(v-if="fields.description").q-mt-md
     label.h-label {{ fields.description.label }}
         q-field.full-width.q-mt-xs.rounded-border(
+          :rules="[rules.required, val => val.length < DESCRIPTION_MAX_LENGTH || `The description must contain less than ${DESCRIPTION_MAX_LENGTH} characters (your description contain ${description.length} characters)`]"
           dense
           maxlength="2000"
           outlined


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

remove character max from description (frontend) #1555

### ✅ Checklist

- Character max length in creating description for proposal has been fixed.

### 🙈 Screenshots
![image](https://user-images.githubusercontent.com/18167258/188469716-10737c51-66a6-478e-8a51-e6776bab0586.png)

