### PR TITLE
feat(proposals): add pull interval for the published proposals

### DIFF
--- a/src/pages/proposals/ProposalDetail.vue
+++ b/src/pages/proposals/ProposalDetail.vue
@@ -350,6 +350,7 @@ export default {
         this.state = 'PUBLISHING'
         await this.publishProposal(proposal.docId)
       } catch (e) {
+        this.state = 'WAITING'
         const message = e.message || e.cause.message
         this.showNotification({ message, color: 'red' })
       }

--- a/src/pages/proposals/ProposalDetail.vue
+++ b/src/pages/proposals/ProposalDetail.vue
@@ -349,6 +349,7 @@ export default {
       try {
         this.state = 'PUBLISHING'
         await this.publishProposal(proposal.docId)
+        this.$router.replace({ params: { data: proposal, isPublishing: true }, query: { refetch: true } })
       } catch (e) {
         this.state = 'WAITING'
         const message = e.message || e.cause.message
@@ -428,6 +429,18 @@ export default {
       this.$store.commit('proposals/setDraftId', draftId)
       this.saveDraft()
       this.$router.push({ name: 'proposal-create', params: { draftId } })
+    },
+
+    async onDelete (proposal) {
+      try {
+        this.state = 'DELETING'
+        await this.deleteProposal(proposal.docId)
+        this.$router.push({ name: 'proposals', params: { data: proposal, isDeleting: true }, query: { refetch: true } })
+      } catch (e) {
+        this.state = 'WAITING'
+        const message = e.message || e.cause.message
+        this.showNotification({ message, color: 'red' })
+      }
     },
 
     async loadVoiceTokenPercentage (username, voice) {
@@ -514,17 +527,6 @@ export default {
           this.$apollo.queries.proposal.refetch()
         }, 700)
       } catch (e) {
-        const message = e.message || e.cause.message
-        this.showNotification({ message, color: 'red' })
-      }
-    },
-    async onDelete (proposal) {
-      try {
-        this.state = 'DELETING'
-        await this.deleteProposal(proposal.docId)
-        this.$router.push({ name: 'proposals', params: { data: proposal, isDeleting: true }, query: { refetch: true } })
-      } catch (e) {
-        this.state = 'WAITING'
         const message = e.message || e.cause.message
         this.showNotification({ message, color: 'red' })
       }

--- a/src/pages/proposals/ProposalList.vue
+++ b/src/pages/proposals/ProposalList.vue
@@ -143,7 +143,7 @@ export default {
       }
     },
 
-    orderByVote () {
+    proposals () {
       const daos = this.dao
       if (!(daos && daos.length && Array.isArray(daos[0].proposal))) return []
 
@@ -164,7 +164,7 @@ export default {
     },
 
     filteredProposals () {
-      const proposalOrder = this.orderByVote
+      const proposalOrder = this.proposals
 
       if (proposalOrder.length === 0) return proposalOrder
 

--- a/src/pages/proposals/ProposalList.vue
+++ b/src/pages/proposals/ProposalList.vue
@@ -219,18 +219,34 @@ export default {
   },
   watch: {
     '$route.query.refetch': {
-      handler: function (refetch) {
+      handler: function (_refetch) {
+        const refetch = true
         const proposal = this.$route.params.data
+
         if (refetch && proposal) {
           this.state = 'RUNNING'
           const isDeleting = this.$route.params.isDeleting
+          const isPublishing = this.$route.params.isPublishing
+
           const pullStagedProposals = setInterval(() => {
             if (isDeleting) {
               const deletedProposal = this.stagedProposals.find(_ =>
                 _.docId === proposal.docId
               )
+
               if (!deletedProposal) {
                 this.state = 'DELETED'
+                this.$router.replace({ params: { data: null }, query: {} })
+                clearInterval(pullStagedProposals)
+              }
+            } else if (isPublishing) {
+              const isPublished = this.proposals.find(_ =>
+                _.docId === proposal.docId
+              )
+
+              this.$apollo.queries.dao.refetch()
+              if (isPublished) {
+                this.state = 'PUBLISHED'
                 this.$router.replace({ params: { data: null }, query: {} })
                 clearInterval(pullStagedProposals)
               }


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)
This PR is adding pull interval after proposal has been published, so that when you click on the proposals after publishing it shows up as publishing and not as staged.

Enter Issue number here
closes https://github.com/hypha-dao/dho-web-client/issues/1488

