### PR TITLE
fix: select options in filter widget has been fixed (#1523, #1556)

### DIFF
--- a/src/pages/dho/Explore.vue
+++ b/src/pages/dho/Explore.vue
@@ -17,7 +17,7 @@ export default {
   },
   data () {
     return {
-      optionArray: ['Creation date ascending', 'Creation date descending', 'Sort alphabetically'],
+      optionArray: [{ label: 'Sort by', disable: true }, 'Creation date ascending', 'Creation date descending', 'Alphabetically'],
       isShowingExploreBanner: true,
       sort: '',
       daoName: '',
@@ -75,13 +75,13 @@ export default {
       }
     },
     order () {
-      if (this.optionArray[0] === this.sort) {
+      if (this.optionArray[1] === this.sort) {
         return { asc: 'createdDate' }
       }
-      if (this.optionArray[1] === this.sort) {
+      if (this.optionArray[2] === this.sort) {
         return { desc: 'createdDate' }
       }
-      if (this.optionArray[2] === this.sort) {
+      if (this.optionArray[3] === this.sort) {
         return { asc: 'details_daoName_n' }
       }
       return null
@@ -168,7 +168,7 @@ export default {
           filterTitle="Search DHOs"
           :optionArray.sync="optionArray"
           :showToggle="false"
-          :defaultOption="0"
+          :defaultOption="1"
           :showViewSelector="false"
           :showCircle="false"
           @update:sort="updateSort"

--- a/src/pages/dho/Members.vue
+++ b/src/pages/dho/Members.vue
@@ -135,7 +135,7 @@ export default {
       sort: '',
       textFilter: null,
       circle: '',
-      optionArray: ['Sort by join date descending', 'Sort by join date ascending', 'Sort Alphabetically (A-Z)'],
+      optionArray: [{ label: 'Sort by', disable: true }, 'Join date descending', 'Join date ascending', 'Alphabetically (A-Z)'],
       circleArray: ['All circles', 'Circle One'],
       showApplicants: false
     }
@@ -385,7 +385,8 @@ export default {
     .col-3.q-pl-sm
       filter-widget.sticky(:view.sync="view",
       :toggle.sync="showApplicants",
-      :toggleDefault="false"
+      :toggleDefault="false",
+      :defaultOption="1",
       :sort.sync="sort",
       :textFilter.sync="textFilter",
       :circle.sync="circle",

--- a/src/pages/proposals/ProposalList.vue
+++ b/src/pages/proposals/ProposalList.vue
@@ -69,7 +69,7 @@ export default {
       textFilter: null,
       sort: 'Sort by last added',
       circle: 'All circles',
-      optionArray: ['Sort by last added'],
+      optionArray: [{ label: 'Sort by', disable: true }, 'Last added'],
       circleArray: ['All circles', 'Circle One'],
       pagination: {
         first: 50,
@@ -435,6 +435,7 @@ export default {
         proposal-list(:username="account" :proposals="filteredProposals" :supply="supply" :view="view")
     .col-3
       filter-widget.sticky(:view.sync="view",
+      :defaultOption="1",
       :sort.sync="sort",
       :textFilter.sync="textFilter",
       :circle.sync="circle",

--- a/src/pages/search/Results.vue
+++ b/src/pages/search/Results.vue
@@ -49,14 +49,16 @@ export default {
     },
     defaultSelector () {
       switch (this.$route.query.filter) {
-        case 'Voting':
+        case 'All':
           return 1
-        case 'Active':
+        case 'Voting':
           return 2
-        case 'Archived':
+        case 'Active':
           return 3
-        case 'Suspended':
+        case 'Archived':
           return 4
+        case 'Suspended':
+          return 5
         default:
           return 1
       }
@@ -204,16 +206,21 @@ export default {
       //   this.params.filter.states = this.params.filter.invalidStates
       // } else {
       // }
-      if (this.filterStatus === 'Active') {
+      if (this.filterStatus === 'All') {
+        this.params.filter.states = this.optionArray.filter(v => (v !== this.filterStatus && v !== 'All' && typeof v !== 'object')).map(s => {
+          return s.toLowerCase()
+        })
+        this.params.filter.states = [...this.params.filter.states, ...this.params.filter.invalidStates]
+      } else if (this.filterStatus === 'Active') {
         // this.params.filter.states = ['approved']
-        this.params.filter.states = this.optionArray.filter(v => (v !== this.filterStatus && typeof v !== 'object')).map(s => {
+        this.params.filter.states = this.optionArray.filter(v => (v !== this.filterStatus && v !== 'All' && typeof v !== 'object')).map(s => {
           if (s === 'Voting') return 'proposed'
           return s.toLowerCase()
         })
         this.params.filter.states = [...this.params.filter.states, ...this.params.filter.invalidStates]
       } else {
         // this.params.filter.states = [this.filterStatus.toLowerCase()]
-        this.params.filter.states = this.optionArray.filter(v => (v !== this.filterStatus && typeof v !== 'object')).map(s => {
+        this.params.filter.states = this.optionArray.filter(v => (v !== this.filterStatus && v !== 'All' && typeof v !== 'object')).map(s => {
           if (s === 'Active') return 'approved'
           if (s === 'Voting') return 'proposed'
           return s.toLowerCase()
@@ -270,7 +277,7 @@ export default {
           sort: 'asc'
         }
       },
-      optionArray: [{ label: 'Filter by', disable: true }, 'Voting', 'Active', 'Archived', 'Suspended'],
+      optionArray: [{ label: 'Filter by', disable: true }, 'All', 'Voting', 'Active', 'Archived', 'Suspended'],
       circleArray: [{ label: 'Sort by', disable: true }, 'Create date ascending', 'Create date descending', 'Alphabetically (A-Z)'],
       results: [],
       filters: [

--- a/src/pages/search/Results.vue
+++ b/src/pages/search/Results.vue
@@ -50,27 +50,27 @@ export default {
     defaultSelector () {
       switch (this.$route.query.filter) {
         case 'Voting':
-          return 0
-        case 'Active':
           return 1
-        case 'Archived':
+        case 'Active':
           return 2
-        case 'Suspended':
+        case 'Archived':
           return 3
+        case 'Suspended':
+          return 4
         default:
-          return 0
+          return 1
       }
     },
     orderDefaultSelector () {
       switch (this.$route.query.order) {
         case 'asc':
-          return 0
-        case 'desc':
           return 1
-        case 'alph':
+        case 'desc':
           return 2
+        case 'alph':
+          return 3
         default:
-          return 0
+          return 1
       }
     }
   },
@@ -206,14 +206,14 @@ export default {
       // }
       if (this.filterStatus === 'Active') {
         // this.params.filter.states = ['approved']
-        this.params.filter.states = this.optionArray.filter(v => v !== this.filterStatus).map(s => {
+        this.params.filter.states = this.optionArray.filter(v => (v !== this.filterStatus && typeof v !== 'object')).map(s => {
           if (s === 'Voting') return 'proposed'
           return s.toLowerCase()
         })
         this.params.filter.states = [...this.params.filter.states, ...this.params.filter.invalidStates]
       } else {
         // this.params.filter.states = [this.filterStatus.toLowerCase()]
-        this.params.filter.states = this.optionArray.filter(v => v !== this.filterStatus).map(s => {
+        this.params.filter.states = this.optionArray.filter(v => (v !== this.filterStatus && typeof v !== 'object')).map(s => {
           if (s === 'Active') return 'approved'
           if (s === 'Voting') return 'proposed'
           return s.toLowerCase()
@@ -229,15 +229,15 @@ export default {
     },
     async orderSelected (value) {
       const query = this.$route.query
-      if (value === this.circleArray[0]) {
+      if (value === this.circleArray[1]) {
         this.params.filter.sort = 'asc'
         query.order = { asc: 'createdDate' }
       }
-      if (value === this.circleArray[1]) {
+      if (value === this.circleArray[2]) {
         this.params.filter.sort = 'desc'
         query.order = { desc: 'createdDate' }
       }
-      if (value === this.circleArray[2]) {
+      if (value === this.circleArray[3]) {
         this.params.filter.sort = 'A-Z'
         query.order = { alph: 'details_title_s' }
       }
@@ -270,8 +270,8 @@ export default {
           sort: 'asc'
         }
       },
-      optionArray: ['Voting', 'Active', 'Archived', 'Suspended'],
-      circleArray: ['Sort by create date ascending', 'Sort by create date descending', 'Sort alphabetically (A-Z)'],
+      optionArray: [{ label: 'Filter by', disable: true }, 'Voting', 'Active', 'Archived', 'Suspended'],
+      circleArray: [{ label: 'Sort by', disable: true }, 'Create date ascending', 'Create date descending', 'Alphabetically (A-Z)'],
       results: [],
       filters: [
         {


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

filter widget: copy cut off #1523
Search filter "show all" #1556

### ✅ Checklist

- Select options in filter widget has been fixed (added "ghost" title before options)
- Added "All" option in search filter

### 🙈 Screenshots
![image](https://user-images.githubusercontent.com/18167258/189088186-bc270f74-57cb-495a-b718-729a8a07e974.png)
![image](https://user-images.githubusercontent.com/18167258/189088320-5d42e40d-cd05-41a4-b732-51c8e666d21f.png)
