### PR TITLE
fix: proposal creation wizard has been improved (#1387)

### DIFF
--- a/src/components/common/button-card.vue
+++ b/src/components/common/button-card.vue
@@ -78,11 +78,11 @@ q-btn.button(
         q-icon(v-if="!hideIcon" :name="icon" size="14px" :color="!outline ? 'primary' : 'white'")
     //- .div.q-pa-none.chip-container.q-px-xs
     //-   chips.nudge-right(v-if="chip && chip.label" :tags="[ chip ]")
-    .row.q-mx-sm.q-my-xxs.text-left(v-if="from && end")
+    .row.q-mx-sm.q-my-xxs.text-left(v-if="from || end")
       //- .h-h7-regular(:class="outline ? 'text-primary' : 'text-white'" :style="{ width: `${width - 16}px`}") From
-      .h-h6.q-mb-xxs(:class="outline ? 'text-primary' : 'text-white'" :style="{ width: `${width - 16}px`}") {{ formatDate(from) }}
-      .h-h7-regular(:class="outline ? 'text-primary' : 'text-white'" :style="{ width: `${width - 16}px`}") To
-      .h-h6.q-py-xxs(:class="outline ? 'text-primary' : 'text-white'" :style="{ width: `${width - 16}px`}") {{ formatDate(end) }}
+      .h-h6.q-mb-xxs(v-if="from" :class="outline ? 'text-primary' : 'text-white'" :style="{ width: `${width - 16}px`}") {{ formatDate(from) }}
+      .h-h7-regular(v-if="from || end" :class="outline ? 'text-primary' : 'text-white'" :style="{ width: `${width - 16}px`}") Until
+      .h-h6.q-py-xxs(v-if="end" :class="outline ? 'text-primary' : 'text-white'" :style="{ width: `${width - 16}px`}") {{ formatDate(end) }}
     .row.q-mx-sm.q-my-xxs.text-left(v-else-if="title || subtitle")
       .h-h5-regular.q-mb-xxs(:class="outline ? 'text-primary' : 'text-white'" :style="{ width: `${width - 16}px`}") {{ title }}
       .h-h5.q-py-xxs(:class="outline ? 'text-primary' : 'text-white'" :style="{ width: `${width - 16}px`}") {{ subtitle }}

--- a/src/css/quasar-classes-override.styl
+++ b/src/css/quasar-classes-override.styl
@@ -132,9 +132,12 @@ a, a:hover, a:focus
 .q-date__calendar-item--in
   color var(--q-color-primary) !important
   .q-btn
-    outline-color var(--q-color-primary) !important
+    color var(--q-color-secondary)
+    outline-color var(--q-color-secondary) !important
     outline-width 1px !important
     outline-style solid !important
+  .bg-primary
+    background var(--q-color-secondary) !important
 
 
 .q-date__range-from:before

--- a/src/store/proposals/index.js
+++ b/src/store/proposals/index.js
@@ -28,6 +28,7 @@ export default {
       periodCount: null,
       detailsPeriod: null,
       startDate: null,
+      endIndex: null,
 
       // For roles/archetypes
       annualUsdSalary: 0,
@@ -231,6 +232,10 @@ export default {
 
     setStartPeriod (state, startPeriod) {
       state.draft.startPeriod = startPeriod
+    },
+
+    setEndIndex (state, endIndex) {
+      state.draft.endIndex = endIndex
     },
 
     setPeriodCount (state, periodCount) {


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Proposal Creation Wizard: Only make possible start dates clickable #1387 

### ✅ Checklist

- Fixed q-date component styles to match design
- Changed the logic of the date range selection

### 🕵️‍♂️ Notes for Code Reviewer

In accordance with the requirements of the task, I changed the logic for choosing dates when creating a proposal. Now the start date is selected on the calendar, and the end date is from the 12 periods proposed below. Implemented saving and restoring the selected dates when moving from the next step back. The only problem I've encountered is "highlighting" selected dates on the calendar. It is technically impossible to do this, because. the highlighting is enabled by using the "range" parameter in the component declaration, but it also activates the selection of the end date on the calendar (which is what we did away with). I also cannot pass something like { from: ..., to: ... } to v-model, because without the "range" parameter it returns only one selected date.

### 🙈 Screenshots

Old flow:
![screencast-localhost_8080-2022 09 15-21_17_48](https://user-images.githubusercontent.com/18167258/190480106-451ca6cd-8a94-4482-babe-ed9a68b7acdc.gif)

New flow:
![screencast-localhost_8080-2022 09 15-21_14_24](https://user-images.githubusercontent.com/18167258/190479598-c2ea7ba9-e8e8-47cf-8b0b-8e5355dcb169.gif)
