### PR TITLE
fix: remove decimals from numbers (#1597)

### DIFF
--- a/src/mixins/format.js
+++ b/src/mixins/format.js
@@ -33,7 +33,7 @@ export const format = {
       return ''
     },
 
-    getFormatedTokenAmount (amount = 0, maxFigures = 4, maxDecimals = 2) {
+    getFormatedTokenAmount (amount = 0, maxFigures = 4, maxDecimals = 0) {
       if (amount === 0) return '0'
       if (amount === undefined) return ''
       if (amount === null) return ''

--- a/src/store/proposals/index.js
+++ b/src/store/proposals/index.js
@@ -356,9 +356,9 @@ export default {
       }
       // TO DO dividir entre 12 para mostrar por mes, mostrar uun lbael para informar que es mensual solo para assignmnt, y archertypes
 
-      commit('setPeg', (ratioUsdEquity * (1 - deferredSan * 0.01)).toFixed(2))
-      commit('setReward', (ratioUsdEquity * deferredSan * 0.01 / rootState.dao.settings.rewardToPegRatio).toFixed(2))
-      commit('setVoice', ratioUsdEquity.toFixed(2))
+      commit('setPeg', (ratioUsdEquity * (1 - deferredSan * 0.01)).toFixed(0))
+      commit('setReward', (ratioUsdEquity * deferredSan * 0.01 / rootState.dao.settings.rewardToPegRatio).toFixed(0))
+      commit('setVoice', ratioUsdEquity.toFixed(0))
 
       // Para badges multiply multiplicar x 100 y sumar 10,000
     },


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Remove decimals from numbers #1597

### ✅ Checklist

Remove decimals from numbers in this pages:
- Proposal detail page (token for Utility, Cash & Voice)
- Proposal creation wizard (token for Utility, Cash & Voice)
- Wallet widget on profile
- Wallet widget on wallet page

### 🙈 Screenshots
![image](https://user-images.githubusercontent.com/18167258/191774258-70e346b4-0aa0-4180-90ab-86027bfe13c6.png)
![image](https://user-images.githubusercontent.com/18167258/191774358-5aa1a1dd-1479-419e-84db-4f235c7f9095.png)
![image](https://user-images.githubusercontent.com/18167258/191774439-e7b87454-ca4e-40d1-9260-e222697a35d3.png)

close #1597