### PR TITLE
chore(github, chromatic): update node version to 16

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '14.x'
+          node-version: '16.x'
       - name: Install dependencies
         run: yarn
         # 👇 Adds Chromatic as a step in the workflow


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)
This PR updates node version number inside chromatic github workflow because it was not building.

[sample error](https://github.com/hypha-dao/dho-web-client/actions/runs/3114035261/jobs/5049399406):
`
error ipfs-unixfs@6.0.9: The engine "node" is incompatible with this module. Expected version ">=16.0.0". Got "14.20.0"
error Found incompatible module.
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Error: Process completed with exit code 1.
`