### PR TITLE
fix: added cut off icons for long titles (#1621)

### DIFF
--- a/src/layouts/MultiDhoLayout.vue
+++ b/src/layouts/MultiDhoLayout.vue
@@ -224,12 +224,13 @@ q-layout(:style="{ 'min-height': 'inherit' }" :view="'lHr Lpr lFr'" ref="layout"
             .main(:class="{'q-pt-lg': $q.screen.gt.sm }")
               .row.full-width.items-center.justify-between
                 // navigation-header
-                .col-auto
+                .col
                   .row(v-if="breadcrumbs")
                     router-link.text-primary.text-underline.text-weight-600(:to="breadcrumbs.tab.link") {{ breadcrumbs.tab.name }}
                   .row
-                    .h-h3(v-if="title") {{ title }}
-                .col
+                    .h-h3.ellipsis(v-if="title") {{ title }}
+                    q-tooltip(:target="true" anchor="top middle").h-h3.ellipsis {{ title }}
+                .col-5
                   .row.justify-end.items-center
                     q-btn.q-mr-xs(:to="{ name: 'configuration' }" unelevated rounded padding="12px" icon="fas fa-cog"  size="sm" :color="isActiveRoute('configuration') ? 'primary' : 'white'" :text-color="isActiveRoute('configuration') ? 'white' : 'primary'" )
                     q-btn(:to="{ name: 'support' }" unelevated rounded padding="12px" icon="far fa-question-circle"  size="sm" color="white" text-color="primary")


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

long titles cut off icons in header #1621 

### ✅ Checklist

- Added cut off icons for long titles
- Added tooltip for titles

### 🙈 Screenshots
![image](https://user-images.githubusercontent.com/18167258/192222025-1c2636d7-0d70-4e94-be19-fc688e3457eb.png)

close #1621 
