### PR TITLE
fix(configuration page): send url only if changed

### DIFF
--- a/src/pages/dho/Configuration.vue
+++ b/src/pages/dho/Configuration.vue
@@ -174,7 +174,7 @@ export default {
       try {
         const { alerts, announcements, title, url, ...form } = this.form
 
-        const _alerts = this.isHypha ? [...alerts] : []
+        const _alerts = this.isHypha ? [...alerts.filter(_ => _.title)] : []
 
         const alertsForCreate = _alerts.filter((_) => !_?.id)
         const alertsForUpdate = _alerts.filter(
@@ -196,14 +196,17 @@ export default {
         const announcementsForDelete = this.initialForm.announcements.filter(
           (_) => _?.id && !_announcements.map(_ => _.id)?.includes(_?.id)
         )
+        /* TODO: Detect and send only changed field
+                 Every field that you send to the action will be updated
+        */
+        const hasURLChanged = this.form.url !== this.initialForm.url
 
         await this.updateDAOSettings({
           docId: this.selectedDao.docId,
           data: {
             ...form,
             daoTitle: title,
-            daoUrl: url,
-
+            ...(hasURLChanged ? { daoUrl: url } : {}),
             proposalsCreationEnabled: form.proposalsCreationEnabled ? 1 : 0,
             membersApplicationEnabled: form.membersApplicationEnabled ? 1 : 0,
             removableBannersEnabled: form.removableBannersEnabled ? 1 : 0,
@@ -223,8 +226,8 @@ export default {
           }
         })
 
-        if (this.form.url !== this.initialForm.url) {
-          this.$router.push(`/${this.form.url}/configuration`)
+        if (hasURLChanged) {
+          setTimeout(() => this.$router.push(`/${this.form.url}/configuration`), 300)
         }
 
         this.initialForm = {


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)
This PR sends url param only if changed because if not it generates error:
`Error: assertion failure with message: URL is already being used, please use a different one url_hypha hypha`
