### PR TITLE
build(commitlint): remove pull request trigger

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,5 +1,5 @@
 name: Lint Commit Messages
-on: [pull_request, push]
+on: [push]
 
 jobs:
   commitlint:


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)
This PR removes triggering commitlint on pull request as it is reductant because it is already trigger on push.