### PR TITLE
refactor: move rounded-border class to app.styl

### DIFF
--- a/src/components/dao/settings-communication.vue
+++ b/src/components/dao/settings-communication.vue
@@ -138,7 +138,4 @@ export default {
 
 .q-editor__content
     color: red !important;
-.rounded-border
-  :first-child
-    border-radius 15px
 </style>

--- a/src/components/filters/filter-widget.vue
+++ b/src/components/filters/filter-widget.vue
@@ -155,9 +155,6 @@ widget(title="Filters")
 </template>
 
 <style lang="stylus" scoped>
-.rounded-border
-  :first-child
-    border-radius 12px
 .text-filter
   height 40px
   :first-child

--- a/src/components/form/custom-period-input.vue
+++ b/src/components/form/custom-period-input.vue
@@ -140,7 +140,4 @@ div.custom-period-input
     color: white;
     ::placeholder
       color: white;
-
-.rounded-border
-  border-radius 15px
 </style>

--- a/src/components/form/text-input-toggle.vue
+++ b/src/components/form/text-input-toggle.vue
@@ -83,7 +83,4 @@ div(class="text-input-toggle")
 </template>
 
 <style lang="stylus" scoped>
-.rounded-border
-  :first-child
-    border-radius 15px
 </style>

--- a/src/components/profiles/contact-info.vue
+++ b/src/components/profiles/contact-info.vue
@@ -172,7 +172,4 @@ widget-editable(title="Contact Info"
 </template>
 
 <style lang="stylus" scoped>
-.rounded-border
-  :first-child
-    border-radius 12px
 </style>

--- a/src/components/profiles/profile-card.vue
+++ b/src/components/profiles/profile-card.vue
@@ -340,10 +340,6 @@ widget-editable(
   border-radius 50%
   overflow hidden
 
-.rounded-border
-  :first-child
-    border-radius 15px
-
 .name-text
   text-overflow ellipsis
   overflow hidden

--- a/src/components/profiles/wallet-adresses.vue
+++ b/src/components/profiles/wallet-adresses.vue
@@ -196,7 +196,4 @@ widget-editable(
 </template>
 
 <style lang="stylus" scoped>
-.rounded-border
-  :first-child
-    border-radius 12px
 </style>

--- a/src/components/profiles/wallet-base.vue
+++ b/src/components/profiles/wallet-base.vue
@@ -189,7 +189,4 @@ widget.wallet-base(:more="more" :no-title="noTitle" morePosition="top" title="Wa
 .icon-section
   min-width: 42px
 
-.rounded-border
-  :first-child
-    border-radius 15px
 </style>

--- a/src/css/app.styl
+++ b/src/css/app.styl
@@ -99,3 +99,11 @@ input[type="number"]
   object-fit: none !important
 .object-scale-down
   object-fit: scale-down !important
+
+
+.rounded-border
+  border-radius 15px
+
+.rounded-border
+  :first-child
+    border-radius 15px  

--- a/src/pages/dho/Plan.vue
+++ b/src/pages/dho/Plan.vue
@@ -255,8 +255,5 @@ export default {
 
 .rounded-full
   border-radius 25px
-.rounded-border
-  :first-child
-    border-radius 15px
 
 </style>

--- a/src/pages/profiles/profile-creation.vue
+++ b/src/pages/profiles/profile-creation.vue
@@ -574,7 +574,4 @@ export default {
 /deep/.q-field__control-container
   padding: 1px !important;
 
-.rounded-border
-  :first-child
-    border-radius 15px
 </style>

--- a/src/pages/proposals/create/OptionsArchetypes.vue
+++ b/src/pages/proposals/create/OptionsArchetypes.vue
@@ -77,7 +77,4 @@ export default {
 </template>
 
 <style lang="stylus" scoped>
-.rounded-border
-  :first-child
-    border-radius 12px
 </style>

--- a/src/pages/proposals/create/OptionsBadges.vue
+++ b/src/pages/proposals/create/OptionsBadges.vue
@@ -90,7 +90,4 @@ export default {
 </template>
 
 <style lang="stylus" scoped>
-.rounded-border
-  :first-child
-    border-radius 12px
 </style>

--- a/src/pages/proposals/create/StepCompensation.vue
+++ b/src/pages/proposals/create/StepCompensation.vue
@@ -636,7 +636,4 @@ widget
   border-radius: 50% !important
 .rounded-border-2
   border-radius 12px
-.rounded-border
-  :first-child
-    border-radius 12px
 </style>

--- a/src/pages/proposals/create/StepDescription.vue
+++ b/src/pages/proposals/create/StepDescription.vue
@@ -211,9 +211,6 @@ widget
 </template>
 
 <style lang="stylus" scoped>
-.rounded-border
-  :first-child
-    border-radius 12px
 
 /deep/.q-field__control-container
   padding: 1px !important;

--- a/src/pages/proposals/create/StepIcon.vue
+++ b/src/pages/proposals/create/StepIcon.vue
@@ -222,7 +222,4 @@ widget
 </template>
 
 <style lang="stylus" scoped>
-.rounded-border
-  :first-child
-    border-radius 12px
 </style>


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)
This PR refactor rounded border class to the app.styl for better reusability
