### PR TITLE
fix: fixed discord and documentation links in dashboard page (#1635)

### DIFF
--- a/src/components/dashboard/support-widget.vue
+++ b/src/components/dashboard/support-widget.vue
@@ -6,9 +6,6 @@ export default {
   },
 
   props: {
-    documentationURL: String,
-
-    discordURL: String
   }
 }
 </script>
@@ -19,9 +16,12 @@ widget(title="Need support?")
     .h-b2.q-mt-md Please read our Documentation for more info. If you are stuck with a problem you can also reach out to us on discord in the "dao-support" channel.
     .row.justify-between.flex.items-center.q-mb-sm
       .col-auto
-        q-btn.q-mt-md.q-px-sm.text-white(noCaps rounded color="primary" type="a" :href="documentationURL" target="_blank") Documentation
+        div {{this.documentationURL}}
+        a(:href="'https://notepad.hypha.earth/5dC66nNXRVGpb1aTHaRJXw'" target="_blank")
+          q-btn.q-mt-md.q-px-sm.text-white(noCaps rounded color="primary") Documentation
       .col
-        q-btn.q-mt-md.q-ml-sm.discord-buttom(unelevated rounded color="primary" icon="fab fa-discord" size="0.7rem" type="a" :href="discordURL" target="_blank")
+        a(:href="'https://discord.com/channels/722537361480613950/732285564384051323'" target="_blank")
+          q-btn.q-mt-md.q-ml-sm.discord-buttom(unelevated rounded color="primary" icon="fab fa-discord" size="0.7rem")
 </template>
 
 <style lang="stylus" scoped>

--- a/src/pages/dho/Home.vue
+++ b/src/pages/dho/Home.vue
@@ -204,7 +204,7 @@ export default {
         metric-link.col(:amount="activeMembersCount" title="Active members" link="members")
       .row.full-width.q-gutter-x-md
         how-it-works.col
-        support-widget.col(:documentationURL="daoSettings.documentationURL" :discordURL="daoSettings.discordURL")
+        support-widget.col
     .col-3.q-ml-md
       new-members(:members="newMembers")
 
@@ -219,7 +219,7 @@ export default {
         .row.q-gutter-y-md.q-ml-xs
           metric-link(:amount="activeProposalsCount" link="proposals" title="New Proposals" ).full-height.full-width
           metric-link(:amount="activeMembersCount" link="members" title="Active Members").full-height.full-width
-          support-widget(:documentationURL="daoSettings.documentationURL" :discordURL="daoSettings.discordURL").full-height.full-width
+          support-widget.full-height.full-width
     .col-12.q-mt-md
       how-it-works.full-height
 
@@ -239,7 +239,7 @@ export default {
       .row.q-mt-md
         how-it-works.full-width
       .row.q-mt-md
-        support-widget.full-width(:documentationURL="daoSettings.documentationURL" :discordURL="daoSettings.discordURL")
+        support-widget.full-width
 </template>
 
 <style lang="stylus" scoped>


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Discord & Documentation button are not linked #1635

### ✅ Checklist

- fixed discord and documentation links in dashboard page

close #1635 