### PR TITLE
fix(plan manager): enable enrolment if the plan is not activated

### DIFF
--- a/src/store/dao/getters.js
+++ b/src/store/dao/getters.js
@@ -2,7 +2,7 @@ import { date } from 'quasar'
 
 export const announcement = ({ announcements }) => announcements.find(_ => _.enabled)
 
-export const canEnroll = ({ plan, meta }) => plan.maxUsers > meta.memberCount
+export const canEnroll = ({ plan, meta }) => plan.isActivated ? plan.maxUsers > meta.memberCount : true
 
 export const daoAlerts = ({ alerts }) => alerts
 export const daoAnnouncements = ({ announcements }) => announcements


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)
This PR enables DAO that are not activated to enrol members
