### PR TITLE
fix(comment input): disable commenting for non-members (#1698)

### DIFF
--- a/src/components/proposals/comment-input.vue
+++ b/src/components/proposals/comment-input.vue
@@ -13,6 +13,13 @@ export default {
     }
   },
 
+  props: {
+    disable: {
+      type: Boolean,
+      default: false
+    }
+  },
+
   methods: {
     createComment () {
       if (this.comment.trim() === '') return
@@ -62,6 +69,8 @@ export default {
       ref="input"
       rounded
       v-model="comment"
+      :disable="disable"
   )
+  q-tooltip(v-if="disable") You must be a member to leave comments
   emoji-picker.absolute-top-right.z-50(@emoji="insert")
 </template>

--- a/src/components/proposals/comments-widget.vue
+++ b/src/components/proposals/comments-widget.vue
@@ -1,4 +1,5 @@
 <script>
+import { mapGetters } from 'vuex'
 
 export default {
   name: 'comments-widget',
@@ -19,6 +20,10 @@ export default {
       type: Boolean,
       default: false
     }
+  },
+
+  computed: {
+    ...mapGetters('accounts', ['isMember'])
   }
 }
 </script>
@@ -36,5 +41,5 @@ widget.comments-widget(:title="`Comments (${comments.length})`")
             @load-comment="(id) => $emit('load-comment', id)"
             v-bind='comment'
         )
-    comment-input.q-my-md(v-show="!disable" color = "heading" @create="(data) => $emit('create', data)")
+    comment-input.q-my-md(v-show="!disable" color = "heading" @create="(data) => $emit('create', data)" :disable="!isMember")
 </template>


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Disable comments for non members #1698 

### ✅ Checklist

- disabled the ability to leave comments to non-members

### 🙈 Screenshots

![Безымянный](https://user-images.githubusercontent.com/18167258/197724228-0af776a8-488b-485d-9396-78880a2f9964.png)

close #1698 