### PR TITLE
fix(design): added save and reset buttons for mobile filter (#1678)

### DIFF
--- a/src/components/filters/filter-widget-mobile.vue
+++ b/src/components/filters/filter-widget-mobile.vue
@@ -20,7 +20,7 @@ transition(name="slide")
   .container
     .top-buttons.q-ma-md
       q-btn(color="internal-bg" text-color="primary" rounded unelevated size="sm" padding="12px" icon="fas fa-times" @click="$emit('close')")
-    filter-widget(v-bind="{ ...$props, ...$attrs, ...$slots }" v-on = "$listeners" :showViewSelector="false").full-height
+    filter-widget(v-bind="{ ...$props, ...$attrs, ...$slots }" v-on = "$listeners" :showViewSelector="false" @close-window="$emit('close')").full-height
     .bottom-buttons
 </template>
 

--- a/src/components/filters/filter-widget.vue
+++ b/src/components/filters/filter-widget.vue
@@ -82,6 +82,16 @@ export default {
     },
     clearSearchInput () {
       this.textFilter = ''
+    },
+    resetFilters () {
+      this.circle = this.circleArray?.[this.circleDefault]
+      this.sort = this.optionArray?.[this.defaultOption]
+      this.toggle = this.toggleDefault
+      this.textFilter = null
+      this.filters.forEach(tag => {
+        tag.enabled = false
+      })
+      this.clearSearchInput()
     }
   },
 
@@ -151,7 +161,23 @@ widget(title="Filters")
       .row.items-center.justify-between.q-mt-sm(v-if="showToggle")
         .h-b2 {{ toggleLabel }}
         q-toggle(v-model="toggle" color="primary" keep-color)
-
+      template(v-if="$q.screen.lt.md")
+        q-btn.q-my-sm.q-px-sm.full-width(
+          :class="'btn-primary-active'"
+          label="Save filters"
+          no-caps
+          rounded
+          unelevated
+          @click="$emit('close-window')"
+        )
+        q-btn.q-px-sm.full-width(
+          :class="'internal-bg'"
+          label="Reset filters"
+          no-caps
+          rounded
+          unelevated
+          @click="resetFilters"
+        )
 </template>
 
 <style lang="stylus" scoped>


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Mobile Design Feedback #1678

### ✅ Checklist

- Added save and reset buttons for mobile filter

### 🕵️‍♂️ Notes for Code Reviewer

Many of the errors in this task were caused by the fact that the browser page was not reloaded after installing the mobile platform in chrome. In fact, there are none.

close #1678

