### PR TITLE
feat: encrypt data and call hypha token sales url 

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -48,6 +48,9 @@ jobs:
           IPFS_PROJECT_SECRET: ${{ secrets.IPFS_PROJECT_SECRET }}
           IPFS_GATEWAY: 'https://hypha.infura-ipfs.io/ipfs/'
           MULTISIG_CONTRACT: 'msig.hypha'
+          HYPHA_TOKEN_SALES_ENCODE_KEY: ${{ secrets.HYPHA_TOKEN_SALES_ENCODE_KEY }}
+          HYPHA_TOKEN_SALES_URL: 'https://tokensale.hypha.earth'
+          
       - name: S3 sync
         uses: jakejarvis/s3-sync-action@master
         with:

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -48,6 +48,8 @@ jobs:
           IPFS_PROJECT_SECRET: ${{ secrets.IPFS_PROJECT_SECRET }}
           IPFS_GATEWAY: 'https://hypha.infura-ipfs.io/ipfs/'
           MULTISIG_CONTRACT: 'msigdhohypha'
+          HYPHA_TOKEN_SALES_ENCODE_KEY: ${{ secrets.HYPHA_TOKEN_SALES_ENCODE_KEY }}
+          HYPHA_TOKEN_SALES_URL: 'https://tokensale.hypha.earth'
 
       - name: S3 sync
         uses: jakejarvis/s3-sync-action@master

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -48,6 +48,8 @@ jobs:
           IPFS_PROJECT_SECRET: ${{ secrets.IPFS_PROJECT_SECRET }}
           IPFS_GATEWAY: 'https://hypha.infura-ipfs.io/ipfs/'
           MULTISIG_CONTRACT: 'msigdhohypha'
+          HYPHA_TOKEN_SALES_ENCODE_KEY: ${{ secrets.HYPHA_TOKEN_SALES_ENCODE_KEY }}
+          HYPHA_TOKEN_SALES_URL: 'https://tokensale.hypha.earth'
 
       - name: S3 sync
         uses: jakejarvis/s3-sync-action@master

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "quasar": "1.15.10",
     "showdown": "^1.9.1",
     "subscriptions-transport-ws": "^0.11.0",
+    "simple-crypto-js": "^3.0.1",
     "turndown": "^7.0.0",
     "ual-anchor": "^1.0.5",
     "ual-seeds": "^1.1.2",

--- a/quasar.conf.js
+++ b/quasar.conf.js
@@ -91,7 +91,9 @@ module.exports = function (ctx) {
         ELASTIC_SEARCH_URL: process.env.ELASTIC_SEARCH_URL,
         ELASTIC_SEARCH_API_KEY: process.env.ELASTIC_SEARCH_API_KEY,
         MULTISIG_CONTRACT: process.env.MULTISIG_CONTRACT,
-        HYPHA_CONTRACT: process.env.HYPHA_CONTRACT
+        HYPHA_CONTRACT: process.env.HYPHA_CONTRACT,
+        HYPHA_TOKEN_SALES_ENCODE_KEY: process.env.HYPHA_TOKEN_SALES_ENCODE_KEY,
+        HYPHA_TOKEN_SALES_URL: process.env.HYPHA_TOKEN_SALES_URL
       },
       scopeHoisting: true,
       vueRouterMode: 'history',

--- a/src/pages/dho/Plan.vue
+++ b/src/pages/dho/Plan.vue
@@ -2,9 +2,6 @@
 import { mapActions, mapGetters } from 'vuex'
 import SimpleCrypto from 'simple-crypto-js'
 
-const HYPHA_TOKEN_SALES_URL = 'https://tokensale.hypha.earth'
-const HYPHA_TOKEN_SALES_ENCODE_KEY = 'test'
-
 const duration = {
   data () {
     return {
@@ -126,7 +123,7 @@ export default {
     },
 
     async goToHyphaTokenSales () {
-      const simpleCrypto = new SimpleCrypto(HYPHA_TOKEN_SALES_ENCODE_KEY)
+      const simpleCrypto = new SimpleCrypto(process.env.SENTRY_DSN)
 
       const data = {
         account: this.account,
@@ -139,7 +136,7 @@ export default {
       const cipher = await simpleCrypto.encrypt(JSON.stringify(data))
       const activationSecret = encodeURIComponent(cipher)
 
-      window.open(`${HYPHA_TOKEN_SALES_URL}/?daoActivation=${activationSecret}`, '_blank')
+      window.open(`${process.env.HYPHA_TOKEN_SALES_URL}/?daoActivation=${activationSecret}`, '_blank')
     },
 
     async activatePlan () {

--- a/src/pages/dho/Plan.vue
+++ b/src/pages/dho/Plan.vue
@@ -123,12 +123,11 @@ export default {
     },
 
     async goToHyphaTokenSales () {
-      const simpleCrypto = new SimpleCrypto(process.env.SENTRY_DSN)
+      const simpleCrypto = new SimpleCrypto(process.env.HYPHA_TOKEN_SALES_ENCODE_KEY)
 
       const data = {
         account: this.account,
         amount: parseFloat((this.selectedPlan.priceHypha - (this.selectedPlan.priceHypha * this.selectedBilling.discountPerc)) * this.selectedBilling.periods).toFixed(2),
-        token: 'EOS',
         accountType: 'hypha_telos',
         disableGoBack: true
       }

--- a/src/pages/dho/Plan.vue
+++ b/src/pages/dho/Plan.vue
@@ -1,5 +1,9 @@
 <script>
 import { mapActions, mapGetters } from 'vuex'
+import SimpleCrypto from 'simple-crypto-js'
+
+const HYPHA_TOKEN_SALES_URL = 'https://tokensale.hypha.earth'
+const HYPHA_TOKEN_SALES_ENCODE_KEY = 'test'
 
 const duration = {
   data () {
@@ -121,6 +125,23 @@ export default {
       }
     },
 
+    async goToHyphaTokenSales () {
+      const simpleCrypto = new SimpleCrypto(HYPHA_TOKEN_SALES_ENCODE_KEY)
+
+      const data = {
+        account: this.account,
+        amount: parseFloat((this.selectedPlan.priceHypha - (this.selectedPlan.priceHypha * this.selectedBilling.discountPerc)) * this.selectedBilling.periods).toFixed(2),
+        token: 'EOS',
+        accountType: 'hypha_telos',
+        disableGoBack: true
+      }
+
+      const cipher = await simpleCrypto.encrypt(JSON.stringify(data))
+      const activationSecret = encodeURIComponent(cipher)
+
+      window.open(`${HYPHA_TOKEN_SALES_URL}/?daoActivation=${activationSecret}`, '_blank')
+    },
+
     async activatePlan () {
       const data = {
         account: this.account,
@@ -226,14 +247,14 @@ export default {
           .col-12.col-sm-12.col-md-12.col-lg-6.row.justify-end
             nav.col-md-12.col-lg-8.q-my-xl.row.q-col-gutter-sm
               .col-12.col-sm-12.col-md-12.col-lg-6
-                a(href="https://tokensale.hypha.earth/" target="_tab").full-width
-                  q-btn.q-px-xl.rounded-border.text-bold.q-mr-xs.full-width(
-                    color="primary"
-                    label="Buy Hypha Token"
-                    no-caps
-                    rounded
-                    unelevated
-                  )
+                q-btn.q-px-xl.rounded-border.text-bold.q-mr-xs.full-width(
+                  color="primary"
+                  label="Buy Hypha Token"
+                  @click="goToHyphaTokenSales"
+                  no-caps
+                  rounded
+                  unelevated
+                )
               .col-12.col-sm-12.col-md-12.col-lg-6
                 q-btn.q-px-xl.rounded-border.text-bold.q-ml-xs.full-width(
                   :disable="!canActivate"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6338,6 +6338,11 @@ crypto-js@^3.1.9-1:
   resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-3.3.0.tgz#846dd1cce2f68aacfa156c8578f926a609b7976b"
   integrity sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q==
 
+crypto-js@^4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/crypto-js/-/crypto-js-4.1.1.tgz#9e485bcf03521041bd85844786b83fb7619736cf"
+  integrity sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw==
+
 css-color-names@0.0.4, css-color-names@^0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/css-color-names/-/css-color-names-0.0.4.tgz#808adc2e79cf84738069b646cb20ec27beb629e0"
@@ -14695,6 +14700,13 @@ signal-exit@^3.0.0, signal-exit@^3.0.2, signal-exit@^3.0.3:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.7.tgz#a9a1767f8af84155114eaabd73f99273c8f59ad9"
   integrity sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==
+
+simple-crypto-js@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/simple-crypto-js/-/simple-crypto-js-3.0.1.tgz#44049f10fd4709ee4a255e78d065bddef8ff905a"
+  integrity sha512-dKhe6jT0WETtXX6NQn9GUTyD6Fp5F9X0ZcUI4XEqZ9dvt4/2h5QxkIl2d+2jH9SXrTBu9m7EsxC8CRaIS8i/dQ==
+  dependencies:
+    crypto-js "^4.1.1"
 
 simple-swizzle@^0.2.2:
   version "0.2.2"


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

#1761 

- Encrypts the data needed for passing to Hypha Token Sales page
- Calls the appropriate URL on Hypha Token Sales page

### ✅ Checklist

- [ ] Github issue details are up to date for people to QA.
- [ ] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

We are encrypting the data in order to prevent users from easily updating the amount / account name / token from URL. 

@arsenijesavic 
This is just example on how to generate the hash for Hypha Token Sales `daoActivation` parameter. Feel free to change this PR as you see it fit.

