### PR TITLE
fix(design): active mode for support icon in multi-dho-layout (#1646)

### DIFF
--- a/src/layouts/MultiDhoLayout.vue
+++ b/src/layouts/MultiDhoLayout.vue
@@ -273,8 +273,10 @@ q-layout(:style="{ 'min-height': 'inherit' }" :view="'lHr Lpr lFr'" ref="layout"
                     .h-h3(v-if="title") {{ title }}
                 .col
                   .row.justify-end.items-center(v-if="$q.screen.gt.md")
-                    q-btn.q-mr-xs(:to="{ name: 'configuration' }" unelevated rounded padding="12px" icon="fas fa-cog"  size="sm" :color="isActiveRoute('configuration') ? 'primary' : 'white'" :text-color="isActiveRoute('configuration') ? 'white' : 'primary'" )
-                    q-btn(:to="{ name: 'support' }" unelevated rounded padding="12px" icon="far fa-question-circle"  size="sm" color="white" text-color="primary")
+                    router-link(:to="{ name: 'configuration' }")
+                      q-btn.q-mr-xs(unelevated rounded padding="12px" icon="fas fa-cog"  size="sm" :color="isActiveRoute('configuration') ? 'primary' : 'white'" :text-color="isActiveRoute('configuration') ? 'white' : 'primary'" )
+                    router-link(:to="{ name: 'support' }")
+                      q-btn(unelevated rounded padding="12px" icon="fas fa-question-circle"  size="sm" :color="isActiveRoute('support') ? 'primary' : 'white'" :text-color="isActiveRoute('support') ? 'white' : 'primary'")
                     q-input.q-mx-md.search(
                       v-model="searchInput"
                       placeholder="Search the whole DAO"


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Support Page: Link Button is not active (blue) when on page #1646

### ✅ Checklist

- Fixed active support icon for multi-dho-layout

### 🙈 Screenshots
![image](https://user-images.githubusercontent.com/18167258/201074948-208a4dfc-c727-4749-b8ba-79a03eed75cb.png)

close #1646 