### PR TITLE
fix: sanitize input editor content (#1566)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
     "libphonenumber-js": "^1.10.6",
     "quasar": "1.15.10",
     "showdown": "^1.9.1",
-    "subscriptions-transport-ws": "^0.11.0",
     "simple-crypto-js": "^3.0.1",
+    "subscriptions-transport-ws": "^0.11.0",
     "turndown": "^7.0.0",
     "ual-anchor": "^1.0.5",
     "ual-seeds": "^1.1.2",
@@ -45,6 +45,7 @@
     "vue": "^2.6.12",
     "vue-croppa": "^1.3.8",
     "vue-matomo": "^4.0.0",
+    "vue-sanitize": "^0.2.2",
     "vuex": "^3.1.3"
   },
   "devDependencies": {

--- a/src/pages/profiles/profile-creation.vue
+++ b/src/pages/profiles/profile-creation.vue
@@ -6,6 +6,11 @@ import { countriesPhoneCode } from '~/mixins/countries-phone-code'
 import { timeZones } from '~/mixins/time-zones'
 import pick from '~/utils/pick'
 import 'vue-croppa/dist/vue-croppa.css'
+import Vue from 'vue'
+import VueSanitize from 'vue-sanitize'
+Vue.use(VueSanitize)
+
+const ABOUT_MAX_LENGTH = 3000
 
 export default {
   name: 'profile-creation',
@@ -63,7 +68,9 @@ export default {
 
       error: null,
       submitting: false,
-      loading: false
+      loading: false,
+
+      ABOUT_MAX_LENGTH: ABOUT_MAX_LENGTH
     }
   },
 
@@ -408,10 +415,10 @@ export default {
       section.row(v-show="activeStepIndex === 1")
         label.h-h4.q-mt-md Tell us something about you
         q-field.full-width.q-mt-xl.rounded-border(
-          :rules="[rules.required]"
+          :rules="[rules.required, val => this.$sanitize(val, { allowedTags: [] }).length < ABOUT_MAX_LENGTH || `The about text must contain less than ${ABOUT_MAX_LENGTH} characters (your about text contain ${this.$sanitize(form.bio, { allowedTags: [] }).length} characters)`]"
           dense
           lazy-rules
-          maxlength="3000"
+          maxlength=3000
           outlined
           ref="bio"
           stack-label

--- a/src/pages/proposals/create/StepDescription.vue
+++ b/src/pages/proposals/create/StepDescription.vue
@@ -2,6 +2,9 @@
 import { validation } from '~/mixins/validation'
 // import { isURL } from 'validator'
 import { toHTML, toMarkdown } from '~/utils/turndown'
+import Vue from 'vue'
+import VueSanitize from 'vue-sanitize'
+Vue.use(VueSanitize)
 
 const TITLE_MAX_LENGTH = 50
 const DESCRIPTION_MAX_LENGTH = 4000
@@ -30,7 +33,7 @@ export default {
 
   computed: {
     nextDisabled () {
-      if (this.title.length > 0 && this.description.length < DESCRIPTION_MAX_LENGTH && this.title.length <= TITLE_MAX_LENGTH) {
+      if (this.title.length > 0 && this.$sanitize(this.description, { allowedTags: [] }).length < DESCRIPTION_MAX_LENGTH && this.title.length <= TITLE_MAX_LENGTH) {
         // if (this.url && isURL(this.url, { require_protocol: true })) {
         //   return false
         // }
@@ -146,9 +149,9 @@ widget
   .col(v-if="fields.description").q-mt-md
     label.h-label {{ fields.description.label }}
         q-field.full-width.q-mt-xs.rounded-border(
-          :rules="[rules.required, val => val.length < DESCRIPTION_MAX_LENGTH || `The description must contain less than ${DESCRIPTION_MAX_LENGTH} characters (your description contain ${description.length} characters)`]"
+          :rules="[rules.required, val => this.$sanitize(val, { allowedTags: [] }).length < DESCRIPTION_MAX_LENGTH || `The description must contain less than ${DESCRIPTION_MAX_LENGTH} characters (your description contain ${this.$sanitize(description, { allowedTags: [] }).length} characters)`]"
           dense
-          maxlength="2000"
+          maxlength=4000
           outlined
           ref="bio"
           stack-label


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Proposal Creation: Sanitise description field #1566

### ✅ Checklist

- added vue-sanitize lib
- sanitize input-editor in proposal description page
- add sanitize validate for about section in profile page
- add sanitize validate for profile-creation page

close #1566 