### PR TITLE
fix(design): markdown shows wrong in preview (#1631)

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "it-all": "^1.0.6",
     "libphonenumber-js": "^1.10.6",
     "quasar": "1.15.10",
+    "remove-markdown": "^0.5.0",
     "showdown": "^1.9.1",
     "simple-crypto-js": "^3.0.1",
     "subscriptions-transport-ws": "^0.11.0",

--- a/src/components/organization/payout-card.vue
+++ b/src/components/organization/payout-card.vue
@@ -6,7 +6,7 @@ widget.bg-internal-bg.q-my-xxs.cursor-pointer(noPadding)
         .h-h5.one-line {{ title }}
     template(v-if="!compact")
       .col(:class="{'col-8': !payments}")
-        .h-b2.text-weight-thin.text-body.q-mr-xl.break-word  {{description.substr(0,150) + (description.length > 150 ? '...' : '')}}
+        .h-b2.text-weight-thin.text-body.q-mr-xl.break-word  {{clearDescription.substr(0,150) + (clearDescription.length > 150 ? '...' : '')}}
       .col-3(v-if="payments && payments.length > 0")
         .row
           .col(v-for="payment of payments")
@@ -16,6 +16,8 @@ widget.bg-internal-bg.q-my-xxs.cursor-pointer(noPadding)
 
 <script>
 import { format } from '~/mixins/format'
+const removeMd = require('remove-markdown')
+
 export default {
   name: 'payout-card',
   mixins: [
@@ -50,6 +52,9 @@ export default {
         '--card-height': this.compact ? '70px' : '90px',
         '--card-ml': this.compact ? '20px' : '30px'
       }
+    },
+    clearDescription () {
+      return removeMd(this.description)
     }
   },
   methods: {

--- a/src/components/organization/role-assignment-card.vue
+++ b/src/components/organization/role-assignment-card.vue
@@ -6,10 +6,12 @@ widget.bg-internal-bg.q-my-xxs.cursor-pointer(noPadding)
         .h-h5.one-line {{ title }}
     template(v-if="!compact")
       .col-8
-        .h-b2.text-weight-thin.text-body.q-mr-xl.break-word {{description.substr(0,150) + (description.length > 150 ? '...' : '')}}
+        .h-b2.text-weight-thin.text-body.q-mr-xl.break-word {{clearDescription.substr(0,150) + (clearDescription.length > 150 ? '...' : '')}}
 </template>
 
 <script>
+const removeMd = require('remove-markdown')
+
 export default {
   name: 'role-assignment-card',
   components: {
@@ -38,6 +40,10 @@ export default {
         '--card-height': this.compact ? '70px' : '90px',
         '--card-ml': this.compact ? '20px' : '30px'
       }
+    },
+
+    clearDescription () {
+      return removeMd(this.description)
     }
   }
 }


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Organisation Page: Markdown shows wrong in preview #1631

### ✅ Checklist

- Fixed wrong preview in payout and role assignment cards

close #1631 