### PR TITLE
build(env): update hypha token sales url with testnet instance url

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -49,10 +49,10 @@ jobs:
           IPFS_GATEWAY: 'https://hypha.infura-ipfs.io/ipfs/'
           MULTISIG_CONTRACT: 'msig.hypha'
           HYPHA_TOKEN_SALES_ENCODE_KEY: ${{ secrets.HYPHA_TOKEN_SALES_ENCODE_KEY }}
-          HYPHA_TOKEN_SALES_URL: 'https://tokensale.hypha.earth'
+          HYPHA_TOKEN_SALES_URL: 'https://dp9rw57cx84kg.cloudfront.net'
           HYPHA_TOKEN_SALES_API_URL: 'http://api-tokensale.hypha.earth'
           HYPHA_TOKEN_SALES_RPC_URL: 'https://telos.greymass.com'
-
+ 
       - name: S3 sync
         uses: jakejarvis/s3-sync-action@master
         with:


### PR DESCRIPTION
### 🗃 #1844 

Points the dev instance of DHO to TestNet version of Hypha Token Sales Page