### PR TITLE
fix(plan manager): add feedback changes

### DIFF
--- a/src/layouts/MultiDhoLayout.vue
+++ b/src/layouts/MultiDhoLayout.vue
@@ -212,7 +212,8 @@ export default {
     async downgradePlan () {
       try {
         await this.downgradeDAOPlan(this.selectedDao.docId)
-      } catch (error) {}
+      } catch (error) {
+      }
     }
   }
 }
@@ -247,7 +248,7 @@ q-layout(:style="{ 'min-height': 'inherit' }" :view="'lHr Lpr lFr'" ref="layout"
           )
         .col-6.q-pl-xs
           q-btn.q-px-xl.rounded-border.text-bold.full-width(
-            :to="{ name: 'plan-manager' }"
+            :to="{ name: 'configuration', query: { tab: 'PLAN' } }"
             color="white"
             text-color="negative"
             label="Renew my current Plan"

--- a/src/pages/dho/Configuration.vue
+++ b/src/pages/dho/Configuration.vue
@@ -256,7 +256,7 @@ export default {
 
   computed: {
     ...mapGetters('accounts', ['account', 'isAdmin']),
-    ...mapGetters('dao', ['daoAlerts', 'daoAnnouncements', 'daoSettings', 'isHypha', 'selectedDao']),
+    ...mapGetters('dao', ['daoAlerts', 'daoAnnouncements', 'daoSettings', 'isHypha', 'selectedDao', 'selectedDaoPlan']),
 
     numberOfChanges () {
       const changed = []
@@ -342,7 +342,7 @@ export default {
     q-tab(name="VOTING" label="Voting" :ripple="false")
     q-tab(name="COMMUNICATION" label="Communication" :ripple="false")
     q-tab(name="DESIGN" label="Design" :ripple="false")
-    q-tab(name="PLAN" label="Plan Manager" :ripple="false")
+    q-tab(name="PLAN" label="Plan Manager" :ripple="false" v-if="selectedDaoPlan.isActivated")
 
   settings-general(v-show="tab === 'GENERAL'" v-bind="{ form, isAdmin, isHypha }" @change="onChange").q-mt-xl
   settings-voting(v-show="tab === 'VOTING'" v-bind="{ form, isAdmin, isHypha }" @change="onChange").q-mt-xl

--- a/src/store/dao/actions.js
+++ b/src/store/dao/actions.js
@@ -242,7 +242,8 @@ export const activateDAOPlan = async function (context, data) {
 
 export const downgradeDAOPlan = async function (context, daoId) {
   const response = await this.$apollo.query({
-    query: require('~/query/_pages/plan-page-query.gql')
+    query: require('~/query/_pages/plan-page-query.gql'),
+    variables: { daoId }
   })
 
   const freePlan = response.data.plans.find(_ => _.name === 'Founders')


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)
it adds changes in last feedback regarding plan manager

Enter Issue number here
closes https://github.com/hypha-dao/dho-web-client/issues/1919
closes https://github.com/hypha-dao/dho-web-client/issues/1806

### ✅ Checklist

- [x] hide plan manager tab if dao is not activated (there is var isActivated)
- [x] when you click on "Renew my current plan" navigate to configuration screen / plan manager tab
- [x] when you click "Downgrade me to the Free Plan" it should trigger `downgradeDAOPlan` function
- [x] Buy Hypha Token button in line #1806

