### PR TITLE
fix(emoji-picker): added border-radius for hover state (#1807)

### DIFF
--- a/src/components/form/emoji-picker.vue
+++ b/src/components/form/emoji-picker.vue
@@ -694,7 +694,7 @@ export default {
 
 <template lang="pug">
 .emoji-picker.relative-position(v-global-click-outside="hidePanel")
-  q-btn(@click="showPanel" unelevated flat)
+  q-btn(@click="showPanel" unelevated flat rounded)
     q-icon(name="fas fa-smile" size="16px" color="body")
 
     .emoji-picker__panel.bg-white.q-pa-sm(v-show="isOpen" )


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Comment: emoji button overflows borders #1807

### ✅ Checklist

- Added border-radius for hover state

### 🙈 Screenshots

![image](https://user-images.githubusercontent.com/18167258/212835929-1c39c967-c078-4db7-8bc9-7c9bf21d1852.png)

close #1807 