### PR TITLE
feat(profile): move contact widget below about

### DIFF
--- a/src/components/profiles/contact-info.vue
+++ b/src/components/profiles/contact-info.vue
@@ -149,7 +149,7 @@ widget-editable(title="Contact Info"
   @onFail="reset"
   :savable= "savable")
   div(:class="{ 'col': $q.screen.md, 'row': !$q.screen.md }")
-    .col-md.col-12(:class="{'q-pr-lg': !$q.screen.md, 'q-pb-sm:': $q.screen.md }")
+    .full-width
       text-input-toggle(
         ref="phone"
         :text.sync = "form.phone"
@@ -159,7 +159,7 @@ widget-editable(title="Contact Info"
         :validateRules="[toggles.phone && rules.required, form.phone && rules.isPhoneNumber]"
         :disable= "!editable"
         type= "tel" )
-    .col-md.col-12
+    .full-width
       text-input-toggle(
         ref="email"
         :text.sync = "form.email"

--- a/src/pages/profiles/Profile.vue
+++ b/src/pages/profiles/Profile.vue
@@ -541,6 +541,7 @@ q-page.full-width.page-profile
     .row.justify-center.q-col-gutter-md(v-if="$q.screen.gt.md")
       .profile-detail-pane.q-gutter-y-md.col-3
         profile-card.info-card(:clickable="false" :username="username" :joinedDate="member && member.createdDate" isApplicant = false view="card" :editButton = "isOwner" @onSave="onSaveProfileCard")
+        contact-info(:emailInfo="emailInfo" :smsInfo="smsInfo" :commPref="commPref" @onSave="onSaveContactInfo" v-if="isOwner")
         base-placeholder(compact v-if="!memberBadges && isOwner" title= "Badges" :subtitle=" isOwner ? 'No Badges yet - apply for a Badge here' : 'No badges to see here.'"
           icon= "fas fa-id-badge" :actionButtons="isOwner ? [{label: 'Apply', color: 'primary', onClick: () => routeTo('proposals/create')}] : []" )
         organizations(:organizations="organizationsList" @onSeeMore="loadMoreOrganizations" :hasMore="organizationsPagination.fetchMore")
@@ -585,10 +586,11 @@ q-page.full-width.page-profile
         base-placeholder(v-if="!(votes && votes.length)" title= "Recent votes" :subtitle=" isOwner ? `You haven't cast any votes yet. Go and take a look at all proposals` : 'No votes casted yet.'"
           icon= "fas fa-vote-yea" :actionButtons="isOwner ? [{label: 'Vote', color: 'primary', onClick: () => routeTo('proposals')}] : []" )
         voting-history(v-if="votes && votes.length" :name="(profile && profile.publicData) ? profile.publicData.name : username" :votes="votes" @onMore="loadMoreVotes")
-        contact-info(:emailInfo="emailInfo" :smsInfo="smsInfo" :commPref="commPref" @onSave="onSaveContactInfo" v-if="isOwner")
+
     //- TODO: Create sub components to remove duplicated code
     .tablet-container(v-else-if="$q.screen.md")
       profile-card.info-card.q-mb-md(:clickable="false" :username="username" :joinedDate="member && member.createdDate" isApplicant = false view="card" :editButton = "isOwner" @onSave="onSaveProfileCard" compact tablet)
+      contact-info.q-mb-md(:emailInfo="emailInfo" :smsInfo="smsInfo" :commPref="commPref" @onSave="onSaveContactInfo" v-if="isOwner")
       organizations.q-mb-md(:organizations="organizationsList" @onSeeMore="loadMoreOrganizations" :hasMore="organizationsPagination.fetchMore" :style="'height: 100px'" tablet).full-width
       widget.q-mb-md(title="My projects")
         q-tabs.q-mt-xxl(
@@ -644,7 +646,7 @@ q-page.full-width.page-profile
       base-placeholder(v-if="!(profile && profile.publicData && profile.publicData.bio) && showBioPlaceholder" title= "About" :subtitle=" isOwner ? `Write something about yourself and let other users know about your motivation to join.` : `Looks like ${this.username} didn't write anything about their motivation to join this DAO yet.`"
         icon= "fas fa-user-edit" :actionButtons="isOwner ? [{label: 'Write biography', color: 'primary', onClick: () => {$refs.about.openEdit(); showBioPlaceholder = false }}] : []" )
       voting-history.q-mb-md(v-if="votes && votes.length" :name="(profile && profile.publicData) ? profile.publicData.name : username" :votes="votes" @onMore="loadMoreVotes")
-      contact-info.q-mb-md(:emailInfo="emailInfo" :smsInfo="smsInfo" :commPref="commPref" @onSave="onSaveContactInfo" v-if="isOwner")
+
     .mobile-container(v-else)
       q-tabs(
         active-color="primary"
@@ -663,6 +665,7 @@ q-page.full-width.page-profile
         q-tab(name="VOTES" label="Votes" :ripple="false")
       .row.q-gutter-y-md.q-mt-xxs(v-if="tab==='INFO'")
         profile-card.info-card(:clickable="false" :username="username" :joinedDate="member && member.createdDate" isApplicant = false view="card" :editButton = "isOwner" @onSave="onSaveProfileCard" compact)
+        contact-info(:emailInfo="emailInfo" :smsInfo="smsInfo" :commPref="commPref" @onSave="onSaveContactInfo" v-if="isOwner").full-width
         base-placeholder(v-if="!memberBadges && isOwner" title= "Badges" :subtitle=" isOwner ? 'No Badges yet - apply for a Badge here' : 'No badges to see here.'"
           icon= "fas fa-id-badge" :actionButtons="isOwner ? [{label: 'Apply', color: 'primary', onClick: () => routeTo('proposals/create')}] : []" ).full-width
         badges-widget(:badges="memberBadges" compact v-if="memberBadges" fromProfile).full-width
@@ -670,7 +673,6 @@ q-page.full-width.page-profile
         wallet(ref="wallet" :more="isOwner" :username="username").full-width
         wallet-adresses(:walletAdresses = "walletAddressForm" @onSave="onSaveWalletAddresses" v-if="isOwner" :isHypha="daoSettings.isHypha").full-width
         multi-sig(v-show="isHyphaOwner" :numberOfPRToSign="numberOfPRToSign").full-width
-        contact-info(:emailInfo="emailInfo" :smsInfo="smsInfo" :commPref="commPref" @onSave="onSaveContactInfo" v-if="isOwner").full-width
 
       .row.q-gutter-y-md.q-mt-xxs(v-if="tab==='ABOUT'")
         base-placeholder(v-if="!(profile && profile.publicData && profile.publicData.bio) && showBioPlaceholder" title= "Biography" :subtitle=" isOwner ? `Write something about yourself and let other users know about your motivation to join.` : `Looks like ${this.username} didn't write anything about their motivation to join this DAO yet.`"


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)
This PR moves contact widget below profile card so that its clear to the user where to input data due to the error on the backend that requires that users has phone or email in order to add other data

### 🙈 Screenshots
<img width="824" alt="Screenshot 2023-01-26 at 09 28 15" src="https://user-images.githubusercontent.com/7712798/214876769-84e591d5-38fa-4021-8535-34d3b62f8773.png">
