### PR TITLE
fix(plan manager): show correct prices

### DIFF
--- a/src/components/dao/settings-plan.vue
+++ b/src/components/dao/settings-plan.vue
@@ -90,8 +90,8 @@ export default {
           name: _.name,
           title: `${_.name} plan`,
           maxMembers: _.maxMemberCount,
-          priceUsd: (parseFloat(_.price.split(' ')[0]) * this.usdPerHypha).toFixed(2),
-          priceHypha: parseFloat(_.price.split(' ')[0]).toFixed(2)
+          priceUsd: parseFloat(_.price.split(' ')[0]).toFixed(2),
+          priceHypha: (parseFloat(_.price.split(' ')[0]) / this.usdPerHypha).toFixed(2)
         })).sort((a, b) => a.priceHypha - b.priceHypha)
     },
 


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)
This PR fixes the issue of usd to hypha conversion.
The prices are not displayed correctly. 

### 🙈 Screenshots
![alt text](https://cdn.discordapp.com/attachments/1067884865015525526/1068234502993870899/Screenshot_2023-01-26_at_12.22.10.png)

