### PR TITLE
fix: remove blink on proposal publish

### DIFF
--- a/src/components/proposals/proposal-view.vue
+++ b/src/components/proposals/proposal-view.vue
@@ -33,7 +33,7 @@ export default {
     /**
      * Whether this is preview step of creation wizard
      */
-    created: String,
+    created: Date,
     start: String,
     icon: String,
     subtitle: String,

--- a/src/pages/proposals/ProposalDetail.vue
+++ b/src/pages/proposals/ProposalDetail.vue
@@ -221,7 +221,7 @@ export default {
             }
 
             this.$apollo.queries.proposal.refetch()
-          }, 300)
+          }, 2000)
         }
       },
       deep: true,
@@ -403,8 +403,8 @@ export default {
 
     async onPublish (proposal) {
       try {
-        this.state = 'PUBLISHING'
         await this.publishProposal(proposal.docId)
+        this.state = 'PUBLISHING'
         this.$router.replace({ params: { data: proposal, isPublishing: true }, query: { refetch: true } })
       } catch (e) {
         this.state = 'WAITING'


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

#1961 

Note: I noticed we are manually refetching the queries instead of using the gql subscriptions, I remember I added subscriptions to this page some time ago, did that got removed for some reason? 
