### PR TITLE
fix: show actual compensation on commitment change

### DIFF
--- a/src/components/proposals/proposal-view.vue
+++ b/src/components/proposals/proposal-view.vue
@@ -74,8 +74,6 @@ export default {
   data () {
     return {
       iconDetails: undefined,
-      newDeferred: undefined,
-      newCommit: undefined,
       showDefferredPopup: false,
       showCommitPopup: false,
       toggle: false,
@@ -88,8 +86,6 @@ export default {
     }
   },
   activated () {
-    this.newDeferred = undefined
-    this.newCommit = undefined
     this.showDefferredPopup = false
     this.showCommitPopup = false
   },
@@ -125,7 +121,7 @@ export default {
       return (this.cycleDurationSec / this.daoSettings.periodDurationSec).toFixed(2)
     },
     commitDifference () {
-      return (this.newCommit ? this.newCommit : this.commit.value) - this.commit.max
+      return (this.commit.value) - this.commit.max
     }
 
   },
@@ -160,14 +156,12 @@ export default {
     async onCommitmentEdit (value) {
       this.showCommitPopup = false
       if (await this.adjustCommitment({ docId: this.docId, commitment: value })) {
-        this.newCommit = value
         this.$emit('change-commit', value)
       }
     },
     async onDeferredEdit (value) {
       this.showDefferredPopup = false
       if (await this.adjustDeferred({ docId: this.docId, deferred: value })) {
-        this.newDeferred = value
         this.$emit('change-deferred', value)
       }
     }
@@ -206,7 +200,7 @@ widget.proposal-view.q-mb-sm
       .row.bg-internal-bg.rounded-border.q-pa-md(:class="{ 'q-ml-xs':$q.screen.gt.md, 'q-mt-sm':$q.screen.lt.md || $q.screen.md }")
         .col-6(v-if="commit !== undefined")
           .text-bold Commitment level
-          .text-grey-7.text-body2 {{ (newCommit !== undefined ? newCommit : commit.value) + '%' }}
+          .text-grey-7.text-body2 {{ (commit.value) + '%' }}
             .text-secondary.text-body2.q-ml-xxs.inline(v-if="ownAssignment && commitDifference") {{commitDifference}} %
             .dynamic-popup(v-if="showCommitPopup")
               proposal-dynamic-popup(
@@ -215,7 +209,7 @@ widget.proposal-view.q-mb-sm
                 :step="5"
                 :min="commit.min"
                 :max="commit.max"
-                :initialValue="(newCommit !== undefined ? newCommit : commit.value)"
+                :initialValue="commit.value"
                 @close="showCommitPopup = false"
                 @save="onCommitmentEdit").q-pa-xxl.absolute
             q-btn.q-ml-xxxl(
@@ -227,7 +221,7 @@ widget.proposal-view.q-mb-sm
               q-tooltip Edit
         .col-6(v-if="deferred !== undefined && type !== 'Payout'")
           .text-bold Deferred amount
-          .text-grey-7.text-body2 {{ (newDeferred !== undefined ? newDeferred : deferred.value) + '%' }}
+          .text-grey-7.text-body2 {{ deferred.value + '%' }}
             .dynamic-popup(v-if="showDefferredPopup")
               proposal-dynamic-popup(
                 title="Adjust Deferred"
@@ -235,7 +229,7 @@ widget.proposal-view.q-mb-sm
                 :step="1"
                 :min="deferred.min"
                 :max="deferred.max"
-                :initialValue="(newDeferred !== undefined ? newDeferred : deferred.value)"
+                :initialValue="deferred.value"
                 @close="showDefferredPopup = false"
                 @save="onDeferredEdit").q-pa-xxl.absolute
             q-btn.q-ml-xxxl(

--- a/src/pages/proposals/ProposalDetail.vue
+++ b/src/pages/proposals/ProposalDetail.vue
@@ -27,6 +27,7 @@ export default {
 
   data () {
     return {
+      optimisticProposal: undefined,
       proposalParsing: proposalParsing,
       pagination: {
         first: 5,
@@ -202,13 +203,13 @@ export default {
   },
 
   watch: {
-
     proposal () {
       this.proposal.cmntsect[0]?.comment.forEach(comment => {
         this.$set(this.commentByIds, comment.id, comment)
         if (this.rootCommentIds.includes(comment.id)) return
         this.rootCommentIds.push(comment.id)
       })
+      this.optimisticProposal = JSON.parse(JSON.stringify(this.proposal))
     },
 
     state: {
@@ -595,6 +596,12 @@ export default {
     },
     onNext () {
       this.page++
+    },
+    onCommitUpdate (val) {
+      this.optimisticProposal = { ...this.optimisticProposal, ...{ lastimeshare: [{ details_timeShareX100_i: val }] } }
+    },
+    onDeferredUpdate (val) {
+      this.optimisticProposal = { ...this.optimisticProposal, details_deferredPercX100_i: val }
     }
   }
 }
@@ -628,7 +635,7 @@ export default {
           .separator-container(v-if="ownAssignment")
             q-separator(color="grey-3" inset)
           proposal-view(
-            :proposal="proposal"
+            :proposal="optimisticProposal"
             :ownAssignment="ownAssignment"
             :class="{'top-no-rounded': ownAssignment}"
             :withToggle="toggle(proposal)"
@@ -649,12 +656,14 @@ export default {
             :type="proposal.__typename === 'Suspend' ? proposal.suspend[0].__typename : proposal.__typename"
             :url="proposalParsing.url(proposal)"
             :icon="proposalParsing.icon(proposal)"
-            :commit="proposalParsing.commit(proposal)"
-            :compensation="proposalParsing.compensation(proposal, daoSettings)"
-            :tokens="proposalParsing.tokens(proposal, periodsOnCycle, daoSettings, isDefaultBadgeMultiplier)"
+            :commit="proposalParsing.commit(optimisticProposal)"
+            :compensation="proposalParsing.compensation(optimisticProposal, daoSettings)"
+            :tokens="proposalParsing.tokens(optimisticProposal, periodsOnCycle, daoSettings, isDefaultBadgeMultiplier)"
             :isBadge="isBadge"
             :pastQuorum="proposalParsing.pastQuorum(proposal)"
             :pastUnity="proposalParsing.pastUnity(proposal)"
+            @change-deferred="onDeferredUpdate"
+            @change-commit="onCommitUpdate"
           )
           comments-widget(
             v-if="!isBadge"
@@ -721,7 +730,7 @@ export default {
       .separator-container(v-if="ownAssignment")
         q-separator(color="grey-3" inset)
       proposal-view(
-        :proposal="proposal"
+        :proposal="optimisticProposal"
         :ownAssignment="ownAssignment"
         :class="{'top-no-rounded': ownAssignment}"
         :withToggle="toggle(proposal)"
@@ -742,13 +751,15 @@ export default {
         :type="proposal.__typename === 'Suspend' ? proposal.suspend[0].__typename : proposal.__typename"
         :url="proposalParsing.url(proposal)"
         :icon="proposalParsing.icon(proposal)"
-        :commit="proposalParsing.commit(proposal)"
-        :compensation="proposalParsing.compensation(proposal, daoSettings)"
-        :tokens="proposalParsing.tokens(proposal, periodsOnCycle, daoSettings, isDefaultBadgeMultiplier)"
+        :commit="proposalParsing.commit(optimisticProposal)"
+        :compensation="proposalParsing.compensation(optimisticProposal, daoSettings)"
+        :tokens="proposalParsing.tokens(optimisticProposal, periodsOnCycle, daoSettings, isDefaultBadgeMultiplier)"
         :isBadge="isBadge"
         :pastQuorum="proposalParsing.pastQuorum(proposal)"
         :pastUnity="proposalParsing.pastUnity(proposal)"
         :purpose="proposalParsing.purpose(proposal)"
+        @change-deferred="onDeferredUpdate"
+        @change-commit="onCommitUpdate"
       )
       comments-widget(
         v-if="!isBadge"

--- a/src/query/proposals/dao-proposal-detail-subs.gql
+++ b/src/query/proposals/dao-proposal-detail-subs.gql
@@ -59,6 +59,7 @@ subscription proposal($docId: String!) {
       }
     }
     ... on Assignment {
+      details_usdSalaryValuePerPhase_a
       cmntsect {
         docId
         comment {

--- a/src/query/proposals/dao-proposal-detail.gql
+++ b/src/query/proposals/dao-proposal-detail.gql
@@ -138,6 +138,7 @@ query proposal($docId: String!, $first: Int!, $offset: Int!) {
       }
     }
     ... on Assignment {
+      details_usdSalaryValuePerPhase_a
       ballot_expiration_t
       details_assignee_n
 

--- a/src/utils/proposal-parsing.js
+++ b/src/utils/proposal-parsing.js
@@ -505,9 +505,11 @@ export function tokens (proposal, periodsOnCycle, daoSettings, isDefaultBadgeMul
       voiceValue = parseFloat(proposal.details_voiceAmount_a)
     }
     if (proposal.__typename === 'Assignment') {
-      utilityValue = parseFloat(proposal.details_rewardSalaryPerPeriod_a) * periodsOnCycle
-      cashValue = parseFloat(proposal.details_pegSalaryPerPeriod_a) * periodsOnCycle
-      voiceValue = parseFloat(proposal.details_voiceSalaryPerPeriod_a) * periodsOnCycle
+      const [amount] = proposal.details_usdSalaryValuePerPhase_a.split(' ')
+      const usdAmount = parseFloat(amount) * periodsOnCycle * commit(proposal).value * 0.01
+      utilityValue = (usdAmount * deferred(proposal).value * 0.01 / daoSettings.rewardToPegRatio)
+      cashValue = (usdAmount * (1 - deferred(proposal).value * 0.01))
+      voiceValue = usdAmount
     }
     if (proposal.__typename === 'Edit' && proposal.original) {
       utilityValue = parseFloat(proposal.original[0].details_rewardSalaryPerPeriod_a)


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

#1596 

- Changed the way the compensation is calculated on proposal detail to be able to display it dynamically while the percentages change. 
- Also did a small refactor to have an optimistic proposal before the DB update happens 