### PR TITLE
fix(proposal-creation): disable next button if not all required are filled (#1986)

### DIFF
--- a/src/pages/proposals/create/StepDescription.vue
+++ b/src/pages/proposals/create/StepDescription.vue
@@ -46,7 +46,7 @@ export default {
           }
           return false
         }
-      } else if (this.title.length > 0 && this.sanitizeDescription.length < DESCRIPTION_MAX_LENGTH && this.title.length <= TITLE_MAX_LENGTH) {
+      } else if (this.sanitizeDescription.length > 0 && this.title.length > 0 && this.sanitizeDescription.length < DESCRIPTION_MAX_LENGTH && this.title.length <= TITLE_MAX_LENGTH) {
         // if (this.url && isURL(this.url, { require_protocol: true })) {
         //   return false
         // }


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Proposal Creation: Disable next button if not all required are filled #1986

### ✅ Checklist

- Fixed disabling next button if not all required are filled

close #1986 