### PR TITLE
fix(top-navigation): remove plan manager button

### DIFF
--- a/src/components/navigation/top-navigation.vue
+++ b/src/components/navigation/top-navigation.vue
@@ -64,7 +64,6 @@ export default {
       .div.inline(v-if="!searching")
         q-btn.q-mr-xxs.icon(flat unelevated rounded padding="12px" icon="fas fa-search"  size="sm" color="white" text-color="primary" @click="searching=!searching")
         q-btn.q-mr-xxs.icon(:to="{ name: 'support' }" unelevated rounded padding="12px" icon="far fa-question-circle"  size="sm" color="white" text-color="primary")
-        q-btn.q-mr-xs(v-if="selectedDaoPlan.isActivated" :to="{ name: 'plan-manager' }" unelevated rounded padding="12px" icon="fas fa-rocket"  size="sm" color="white" text-color="primary" )
       q-input.q-mr-md.search.inline(
         v-if="searching"
         v-model="searchInput"

--- a/src/components/navigation/top-navigation.vue
+++ b/src/components/navigation/top-navigation.vue
@@ -18,7 +18,6 @@ export default {
     },
     dhos: undefined,
     profile: Object,
-    selectedDaoPlan: Object,
     disabledSelector: Boolean
   },
 
@@ -64,6 +63,7 @@ export default {
       .div.inline(v-if="!searching")
         q-btn.q-mr-xxs.icon(flat unelevated rounded padding="12px" icon="fas fa-search"  size="sm" color="white" text-color="primary" @click="searching=!searching")
         q-btn.q-mr-xxs.icon(:to="{ name: 'support' }" unelevated rounded padding="12px" icon="far fa-question-circle"  size="sm" color="white" text-color="primary")
+        q-btn.q-mr-xs(v-if="selectedDaoPlan.isActivated" :to="{ name: 'plan-manager' }" unelevated rounded padding="12px" icon="fas fa-rocket"  size="sm" color="white" text-color="primary" )
       q-input.q-mr-md.search.inline(
         v-if="searching"
         v-model="searchInput"

--- a/src/layouts/MultiDhoLayout.vue
+++ b/src/layouts/MultiDhoLayout.vue
@@ -258,7 +258,7 @@ q-layout(:style="{ 'min-height': 'inherit' }" :view="'lHr Lpr lFr'" ref="layout"
           )
   // dho-switcher.fixed-left
   q-header.bg-white(v-if="$q.screen.lt.lg")
-    top-navigation(:profile="profile" @toggle-sidebar="right = true" @search="onSearch" :dho="dho" :dhos="getDaos($apolloData.data.member)" :selectedDaoPlan="selectedDaoPlan")
+    top-navigation(:profile="profile" @toggle-sidebar="right = true" @search="onSearch" :dho="dho" :dhos="getDaos($apolloData.data.member)")
   q-page-container.bg-white.window-height.q-py-md(:class="{ 'q-pr-md': $q.screen.gt.md, 'q-px-xs': !$q.screen.gt.md}")
     .bg-internal-bg.content.full-height
       q-resize-observer(@resize="onContainerResize")


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)
This PR removes the plan manager button from the top navigation since the plan manager is no longer a separate page
