### PR TITLE
fix(style): rename rounded-corners to the rounded-full

### DIFF
--- a/src/components/common/base-banner.vue
+++ b/src/components/common/base-banner.vue
@@ -64,7 +64,7 @@ export default {
 </script>
 
 <template lang="pug">
-.base-banner.full-width.rounded-corners.relative-position.overflow-hidden(:style="{'background': color}" :class="{'compact-banner' : compact}")
+.base-banner.full-width.rounded-full.relative-position.overflow-hidden(:style="{'background': color}" :class="{'compact-banner' : compact}")
   #banner-pattern.absolute(:style="{'background': `url('${pattern}') repeat`, 'background-size': '200px' }" v-if="pattern")
   #banner-image.absolute(:style="{'background': `url('${background}') no-repeat`, 'background-size': 'cover' }" v-if="background")
   #linear-gradient.absolute.z-40(v-if="gradient")
@@ -85,8 +85,8 @@ export default {
     section.row
       div(v-if="!compact" :class="{'col-6': split || hasSlot('right')}")
         h3.q-pa-none.q-ma-none.h-h2.text-white.text-weight-700 {{title}}
-        p.h-b1.text-white.q-my-lg.text-weight-300 {{description}}
-        nav
+        p.h-b1.text-white.q-my-lg.text-weight-500.leading-loose {{description}}
+        nav.q-mt-xl
           slot(name="buttons")
       .col-6(v-if="!compact")
         slot(name="right")
@@ -110,9 +110,5 @@ export default {
   background-repeat: no-repeat
   background-size: cover
   background-position-x right
-
-.rounded-corners
-  border-radius 32px
-  -webkit-mask-image: -webkit-radial-gradient(white, black);
 
 </style>


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)
This PR fixes issue with wrong class name for the base banner that was making corner sharp



<img width="1161" alt="Screenshot 2023-02-16 at 10 47 18" src="https://user-images.githubusercontent.com/7712798/219432104-5aee0289-d75e-4b04-be2a-0440e76d882d.png">
