### PR TITLE
fix: remove BASE_APP when configuring ppp-client-api

### DIFF
--- a/src/boot/ppp.js
+++ b/src/boot/ppp.js
@@ -1,6 +1,6 @@
 import PPP from '@hypha-dao/ppp-client-api'
 
 export default async ({ store }) => {
-  PPP.configure(process.env.PPP_ENV, 'BASE_APP')
+  PPP.configure(process.env.PPP_ENV)
   store.$ppp = PPP
 }


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

Reverts the configuration for PPP service.