### PR TITLE
fix(proposal-history): hide staging and voting proposals in history page (#DEV-614)

### DIFF
--- a/src/pages/proposals/ProposalHistory.vue
+++ b/src/pages/proposals/ProposalHistory.vue
@@ -69,6 +69,8 @@ export default {
       return this.archivedProposals.filter((proposal) => {
         return enabledFilters.some((filter) => {
           return filter.filter(proposal) &&
+            proposal.details_state_s !== 'drafted' &&
+            proposal.details_state_s !== 'proposed' &&
             (!this.textFilter || this.textFilter.length === 0 ||
             (proposal.details_title_s?.toLocaleLowerCase() || '').includes(this.textFilter.toLocaleLowerCase()))
         })


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

https://linear.app/hypha/issue/DEV-614/staging-proposals-and-active-proposals-appear-in-the-history

### ✅ Checklist

- Fixed history page

close https://linear.app/hypha/issue/DEV-614/staging-proposals-and-active-proposals-appear-in-the-history