### PR TITLE
fix(proposal-editing): returns the previously selected parent circle when edited (#DEV-616)

### DIFF
--- a/src/pages/proposals/ProposalDetail.vue
+++ b/src/pages/proposals/ProposalDetail.vue
@@ -507,7 +507,17 @@ export default {
       this.$store.commit('proposals/setDeferred', parseFloat(this?.proposal?.details_deferredPercX100_i))
 
       if (this.proposal.__typename === PROPOSAL_TYPE.CIRCLE) {
-        // this.$store.commit('proposals/setParent', this.proposal?.details_purpose_s)
+        this.$store.commit('proposals/setCircle', {
+          label: this.proposal?.parentcircle[0]?.name,
+          value: this.proposal?.parentcircle[0]?.id
+        })
+      }
+
+      if (this.proposal.__typename === PROPOSAL_TYPE.POLICY) {
+        this.$store.commit('proposals/setCircle', {
+          label: this.proposal?.parentcircle[0]?.name,
+          value: this.proposal?.parentcircle[0]?.id
+        })
       }
 
       if (this.proposal.__typename === PROPOSAL_TYPE.PAYOUT) {

--- a/src/store/proposals/index.js
+++ b/src/store/proposals/index.js
@@ -772,6 +772,29 @@ export default {
               { label: 'voting_method', value: ['string', draft.votingMethod.value] }
             ]
             break
+
+          case PROPOSAL_TYPE.CIRCLE :
+            content = [
+              { label: 'content_group_label', value: ['string', 'details'] },
+              { label: 'title', value: ['string', draft.title] },
+              { label: 'description', value: ['string', draft.description] },
+              { label: 'name', value: ['string', ''] },
+              { label: 'purpose', value: ['string', draft.purpose] },
+              ...(draft.circle ? [{ label: 'parent_circle', value: ['int64', draft.circle.value] }] : [])
+            ]
+            break
+
+          case PROPOSAL_TYPE.POLICY :
+            content = [
+              { label: 'content_group_label', value: ['string', 'details'] },
+              { label: 'title', value: ['string', draft.title] },
+              { label: 'description', value: ['string', draft.description] },
+              { label: 'url', value: ['string', draft.url] },
+              { label: 'name', value: ['string', ''] },
+              ...(draft.circle ? [{ label: 'parent_circle', value: ['int64', draft.circle.value] }] : []),
+              ...(draft.masterPolicy ? [{ label: 'master_policy', value: ['int64', draft.masterPolicy.value] }] : [])
+            ]
+            break
         }
         if (content) {
           const actions = [{


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

https://linear.app/hypha/issue/DEV-616/editing-circle-proposal-on-staging-is-not-capturing-parent-circle

### ✅ Checklist

- Fixed selected parent circle in circle and policy types

fixed DEV-616