### PR TITLE
fix(explore): colors in explore by widget (#DEV-632)

### DIFF
--- a/src/components/common/explore-by-widget.vue
+++ b/src/components/common/explore-by-widget.vue
@@ -19,8 +19,8 @@ export default {
 </script>
 
 <template lang="pug">
-widget.sticky.bg-secondary.rounded.full-width.q-pa-md.q-mb-md(
-  :textColor="'white'"
+widget.sticky.bg-white.rounded.full-width.q-pa-md.q-mb-md(
+  :textColor="'black'"
   :title="'Explore by:'"
 )
   .select-option(@click="$emit('change', EXPLORE_BY.DAOS)")
@@ -43,7 +43,7 @@ widget.sticky.bg-secondary.rounded.full-width.q-pa-md.q-mb-md(
   margin-top: 15px
   cursor: pointer
   .select-option-label
-    color: white
+    color: black
     font-size: 14px
     font-weight: 600
   .select-option-dot
@@ -54,12 +54,12 @@ widget.sticky.bg-secondary.rounded.full-width.q-pa-md.q-mb-md(
     width: 22px
     height: 22px
     opacity: 0.18
-    background: #fff
+    background: #252F5D
   .selected
     opacity: 1
   .selected::before
     content: ''
-    background: #3F64EE
+    background: #FFF
     width: 10px
     height: 10px
     border-radius: 50%


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

https://linear.app/hypha/issue/DEV-632/make-explore-by-background-white-again-like-filter-card-see-link-for

### ✅ Checklist

- Fixed colors in "explore by" widget

### 🙈 Screenshots

<img width="304" alt="image" src="https://user-images.githubusercontent.com/18167258/234508548-2fb1ba32-f712-4a30-81d0-56d09f546a10.png">

fixed DEV-632