### PR TITLE
fix(treasury): default tab (#DEV-755)

### DIFF
--- a/src/pages/dho/Treasury.vue
+++ b/src/pages/dho/Treasury.vue
@@ -119,6 +119,11 @@ export default {
           daoId: this.selectedDao.docId
         }
       },
+      result (res) {
+        if (!res.data?.queryDao?.[0].settings?.[0].treasuryAccount) {
+          this.tab = MULTISIG_TABS.HISTORY
+        }
+      },
       skip () { return !this.selectedDao?.docId }
     },
     redemptions: {


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

https://linear.app/hypha/issue/DEV-755/set-history-as-default-tab-if-its-only-one

### ✅ Checklist

- Fixed default tab in treasury page

fixed DEV-755