### PR TITLE
fix(proposal-history): hide view selector in proposal history page (#DEV-754)

### DIFF
--- a/src/pages/proposals/ProposalHistory.vue
+++ b/src/pages/proposals/ProposalHistory.vue
@@ -213,6 +213,7 @@ q-page.page-proposals
       :circleArray.sync="circleArray"
       :viewSelectorLabel="'View'",
       :chipsFiltersLabel="'Proposal types'",
+      :showViewSelector="false"
       :filters.sync="filters"
       )
   .row.full-width(v-if="!$q.screen.gt.md").q-my-md


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

https://linear.app/hypha/issue/DEV-754/pagination-not-working-on-proposal-history

### ✅ Checklist

- Hide view selector in proposal history page

### 🕵️‍♂️ Notes for Code Reviewer

I checked it on dev and it works correctly

fixed DEV-754
