### PR TITLE
fix(proposals-history): pagination improvements (#DEV-754)

### DIFF
--- a/src/pages/proposals/ProposalHistory.vue
+++ b/src/pages/proposals/ProposalHistory.vue
@@ -21,7 +21,7 @@ export default {
     archivedProposals: {
       skip: true,
       query: () => require('../../query/proposals/dao-proposals-history.gql'),
-      update: data => data?.queryDao[0]?.closedprops,
+      update: data => data?.queryDao[0]?.votable,
       variables () {
         return {
           docId: this.selectedDao.docId,
@@ -157,14 +157,14 @@ export default {
             },
             fetchPolicy: 'network-only',
             updateQuery: (prev, { fetchMoreResult }) => {
-              if (fetchMoreResult.queryDao[0].closedprops.length < this.pagination.first) this.pagination.more = false
+              if (fetchMoreResult.queryDao[0].votable.length < this.pagination.first) this.pagination.more = false
               return {
                 queryDao: [
                   {
                     ...fetchMoreResult.queryDao[0],
-                    closedprops: [
-                      ...prev.queryDao[0].closedprops,
-                      ...fetchMoreResult.queryDao[0].closedprops
+                    votable: [
+                      ...prev.queryDao[0].votable,
+                      ...fetchMoreResult.queryDao[0].votable
                     ]
                   }
                 ]

--- a/src/query/proposals/dao-proposals-history.gql
+++ b/src/query/proposals/dao-proposals-history.gql
@@ -2,7 +2,7 @@ query historyProposals($docId: String!, $first: Int!, $offset: Int!) {
   queryDao(filter: { docId: { eq: $docId } }) {
     details_daoName_n
     docId
-    closedprops(first: $first, offset: $offset, order: { desc: createdDate }) {
+    votable(first: $first, offset: $offset, order: { desc: createdDate }) {
       docId
       type
 


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

https://linear.app/hypha/issue/DEV-754/pagination-not-working-on-proposal-history

### ✅ Checklist

- Fixed pagination in proposals history page

Comments: I returned to the old version of the output of the history of proposals. It took quite some time to find the reason, which is that the closedprops field that Gerry created to filter this on the server returns only 18 records (due to this, it seemed that the pagination was not working). In the old version, I filter records on the template. Let's leave it like that for now (because it works), but in the future Gerry should check how closedprops are formed in graphql

fixed DEV-754