### PR TITLE
fix(treasury): filter history tab (#DEV-759)

### DIFF
--- a/src/pages/dho/Treasury.vue
+++ b/src/pages/dho/Treasury.vue
@@ -166,7 +166,6 @@ export default {
         const uniqueTreasurers = [...new Set(treasurers)]
 
         this.treasurers = uniqueTreasurers
-
         return formattedRedemptions
       },
       skip () {
@@ -727,7 +726,7 @@ q-page.page-treasury
         div(v-if="tab === MULTISIG_TABS.HISTORY")
           q-table.treasury-table(
             :columns="tabsConfig.history.columns"
-            :data="redemptions.filter(redemption => redemption.paidBy?.details_creator_n)"
+            :data="treasuryAccount ? redemptions.filter(redemption => redemption.paidBy?.msiginfo?.[0]?.details_state_s === 'executed') : redemptions.filter(redemption => redemption.paidBy?.details_creator_n)"
             :loading="loading"
             @request="onRequest"
             row-key="redemption.id"

--- a/src/query/treasury/dao-redemptions.gql
+++ b/src/query/treasury/dao-redemptions.gql
@@ -27,6 +27,7 @@ query daoRedemptions(
           msiginfo {
             type
             details_proposalName_n
+            details_state_s
           }
         }
       }


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

https://linear.app/hypha/issue/DEV-759/dont-show-redemptions-that-are-still-open-in-history-tab

### ✅ Checklist

- Fixed filter in treasury history tab

fixed DEV-759