### PR TITLE
fix(treasury): add styles for circle avatar (#DEV-787)

### DIFF
--- a/src/pages/dho/Treasury.vue
+++ b/src/pages/dho/Treasury.vue
@@ -769,6 +769,7 @@ q-page.page-treasury
                     v-if="props.row.paidBy && props.row.paidBy.details_creator_n && profiles[props.row.paidBy.details_creator_n]"
                     :src="profiles[props.row.paidBy.details_creator_n].avatar"
                     size="25px"
+                    :style="{ 'border-radius': '50%', 'height': '25px', 'width': '25px' }"
                   )
                     q-tooltip Signed by {{ props.row.paidBy.details_creator_n }}
                   q-icon.icon-placeholder.q-mr-xs(


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

https://linear.app/hypha/issue/DEV-787/set-treasurer-avatar-to-circle

### ✅ Checklist

- Fixed styles for treasurer avatar

### 🙈 Screenshots
<img width="712" alt="image" src="https://github.com/hypha-dao/dho-web-client/assets/18167258/0bd86010-6feb-4710-a54a-20e74e53b32f">

fixed DEV-787