### PR TITLE
fix(period-calendar): active period icon color (#DEV-726)

### DIFF
--- a/src/components/assignments/period-calendar-card.vue
+++ b/src/components/assignments/period-calendar-card.vue
@@ -33,11 +33,11 @@ export default {
   computed: {
     backgroundColor () {
       if (this.claimed) return 'positive'
-      if (this.end < this.now && !this.calimed) return 'primary'
+      if (this.start < this.now && !this.claimed) return 'primary'
       return 'disabled'
     },
     textColor () {
-      return getPaletteColor(this.backgroundColor === 'disabled' ? 'primary' : 'white')
+      return getPaletteColor(this.backgroundColor === 'disabled' || this.backgroundColor === 'primary' ? 'primary' : 'white')
     },
 
     icon () {


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

https://linear.app/hypha/issue/DEV-726/role-assignment-active-period-icon-should-be-blu

### ✅ Checklist

- Fixed color for active period icon

fixed DEV-726