### PR TITLE
fix(filter-widget): overflow ellipsis in filter-widget select (#DEV-581)

### DIFF
--- a/src/components/filters/filter-widget.vue
+++ b/src/components/filters/filter-widget.vue
@@ -167,6 +167,8 @@ widget(:title="$t('filters.filter-widget.filters')")
     white-space nowrap
     padding-right 10px
     height 30px !important
-    display flex
+    display inline-block
+    padding-top 5px
     align-items center
+    overflow hidden
 </style>


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

https://linear.app/hypha/issue/DEV-581/dropdown-menu-arrow-overlapping-text

### ✅ Checklist

- Added ellipsis text in filter widget select

### 🙈 Screenshots
<img width="261" alt="image" src="https://github.com/hypha-dao/dho-web-client/assets/18167258/729078e8-96ce-4ac3-8076-495331b6cacc">


fixed DEV-581