### PR TITLE
chore: replacing greymass node server with the load balancer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,4 +31,4 @@ IPFS_PROJECT_SECRET=
 
 MULTISIG_CONTRACT=msig.hypha
 HYPHA_TOKEN_SALES_API_URL= 'http://api-tokensale.hypha.earth'
-HYPHA_TOKEN_SALES_RPC_URL= 'https://telos.greymass.com'
+HYPHA_TOKEN_SALES_RPC_URL= 'https://mainnet.telos.net'

--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -51,7 +51,8 @@ jobs:
           HYPHA_TOKEN_SALES_ENCODE_KEY: ${{ secrets.HYPHA_TOKEN_SALES_ENCODE_KEY }}
           HYPHA_TOKEN_SALES_URL: 'https://dp9rw57cx84kg.cloudfront.net'
           HYPHA_TOKEN_SALES_API_URL: 'http://api-tokensale.hypha.earth'
-          HYPHA_TOKEN_SALES_RPC_URL: 'https://telos.greymass.com'
+          HYPHA_TOKEN_SALES_RPC_URL: 'https://mainnet.telos.net
+'
           ROOT_DAO_ID: ${{vars.ROOT_DAO_ID}}
           ROOT_DAO_SLUG: ${{vars.ROOT_DAO_SLUG}}
           HEALTH_ENDPOINT: ${{ vars.HEALTH_ENDPOINT }}

--- a/.github/workflows/deploy-eos-dev.yml
+++ b/.github/workflows/deploy-eos-dev.yml
@@ -66,7 +66,8 @@ jobs:
           HYPHA_TOKEN_SALES_ENCODE_KEY: ${{ secrets.HYPHA_TOKEN_SALES_ENCODE_KEY }}
           HYPHA_TOKEN_SALES_URL: ${{ vars.HYPHA_TOKEN_SALES_URL }}
           HYPHA_TOKEN_SALES_API_URL: 'http://api-tokensale.hypha.earth'
-          HYPHA_TOKEN_SALES_RPC_URL: 'https://telos.greymass.com'
+          HYPHA_TOKEN_SALES_RPC_URL: 'https://mainnet.telos.net
+'
 
           CAPTCHA_PUBLIC_KEY: ${{ vars.CAPTCHA_PUBLIC_KEY }}
           CAPTCHA_HOST: ${{ vars.CAPTCHA_HOST }}

--- a/.github/workflows/deploy-eos-prod.yml
+++ b/.github/workflows/deploy-eos-prod.yml
@@ -67,7 +67,8 @@ jobs:
           HYPHA_TOKEN_SALES_ENCODE_KEY: ${{ secrets.HYPHA_TOKEN_SALES_ENCODE_KEY }}
           HYPHA_TOKEN_SALES_URL: ${{ vars.HYPHA_TOKEN_SALES_URL }}
           HYPHA_TOKEN_SALES_API_URL: 'http://api-tokensale.hypha.earth'
-          HYPHA_TOKEN_SALES_RPC_URL: 'https://telos.greymass.com'
+          HYPHA_TOKEN_SALES_RPC_URL: 'https://mainnet.telos.net
+'
 
           CAPTCHA_PUBLIC_KEY: ${{ vars.CAPTCHA_PUBLIC_KEY }}
           CAPTCHA_HOST: ${{ vars.CAPTCHA_HOST }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -55,7 +55,7 @@ jobs:
           HYPHA_TOKEN_SALES_ENCODE_KEY: ${{ secrets.HYPHA_TOKEN_SALES_ENCODE_KEY }}
           HYPHA_TOKEN_SALES_URL: 'https://tokensale.hypha.earth'
           HYPHA_TOKEN_SALES_API_URL: 'http://api-tokensale.hypha.earth'
-          HYPHA_TOKEN_SALES_RPC_URL: 'https://telos.greymass.com'
+          HYPHA_TOKEN_SALES_RPC_URL: 'https://mainnet.telos.net'
           ROOT_DAO_ID: ${{vars.ROOT_DAO_ID}}
           ROOT_DAO_SLUG: ${{vars.ROOT_DAO_SLUG}}
           HEALTH_ENDPOINT: ${{ vars.HEALTH_ENDPOINT }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -57,7 +57,7 @@ jobs:
           HYPHA_TOKEN_SALES_ENCODE_KEY: ${{ secrets.HYPHA_TOKEN_SALES_ENCODE_KEY }}
           HYPHA_TOKEN_SALES_URL: 'https://tokensale.hypha.earth'
           HYPHA_TOKEN_SALES_API_URL: 'http://api-tokensale.hypha.earth'
-          HYPHA_TOKEN_SALES_RPC_URL: 'https://telos.greymass.com'
+          HYPHA_TOKEN_SALES_RPC_URL: 'https://mainnet.telos.net
           ROOT_DAO_ID: ${{vars.ROOT_DAO_ID}}
           ROOT_DAO_SLUG: ${{vars.ROOT_DAO_SLUG}}
           HEALTH_ENDPOINT: ${{ vars.HEALTH_ENDPOINT }}


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

- greymass node was down for 24 hours recently - best to just use load balancer
- only affects hypha sale


### ✅ Checklist

- [ ] Github issue details are up to date for people to QA.
- [x] I have tested all my changes.

### 🕵️‍♂️ Notes for Code Reviewer

Generally the load balancer - mainnet.telos.net - should be more stable

The sales contract is only on Telos

### 🙈 Screenshots

### 👯‍♀️ Paired with

