### PR TITLE
fix(proposals): added filter for hide passed proposals from active proposals (#DEV-863)

### DIFF
--- a/src/pages/proposals/ProposalList.vue
+++ b/src/pages/proposals/ProposalList.vue
@@ -528,8 +528,7 @@ export default {
       //   })
       //   return [...withOutVote, ...withVote]
       // }
-
-      return daos[0].proposal
+      return daos[0].proposal.filter(proposal => new Date(proposal.ballot_expiration_t) > new Date(Date.now()))
     },
 
     filteredProposals () {


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)

https://linear.app/hypha/issue/DEV-863/proposal-that-passed-and-closed-52-days-ago-is-still-appearing-as-an

### ✅ Checklist

- Fixed bug when active proposals contains passed proposals

 fixed DEV-863