### PR TITLE
fix(settings-token): add correct maping for decay

### DIFF
--- a/src/components/dao/settings-tokens.vue
+++ b/src/components/dao/settings-tokens.vue
@@ -10,6 +10,9 @@ const mapCurrency = (currency) => (_) => ({
   ...currency[_]
 })
 
+const MIN_DECAY = 0
+const MAX_DECAY = 10000000
+
 export default {
   name: 'settings-token',
   mixins: [validation],
@@ -84,7 +87,7 @@ export default {
         if (isValid) {
           await this.createTokens({
             ...this.tokens,
-            voiceDecayPercent: map(this.tokens.voiceDecayPercent, 0, 100, 0, 10000000)
+            voiceDecayPercent: map(this.tokens.voiceDecayPercent, 0, 100, MIN_DECAY, MAX_DECAY)
           })
         }
       } catch (e) {
@@ -126,7 +129,7 @@ export default {
         voiceDigits: voiceDigits.split('.')[1].length,
         voiceTokenMultiplier: this.daoSettings.settings_voiceTokenMultiplier_i,
         voiceDecayPeriod: this.daoSettings.settings_voiceTokenDecayPeriod_i,
-        voiceDecayPercent: map(this.daoSettings.settings_voiceTokenDecayPerPeriodX10M_i, 0, 10000000, 0, 100)
+        voiceDecayPercent: map(this.daoSettings.settings_voiceTokenDecayPerPeriodX10M_i, MIN_DECAY, MAX_DECAY, 0, 100)
 
       }
     }


### PR DESCRIPTION
### 🗃 Github Issue Or Explanation for this PR. (What is it supposed to do and Why is needed)
This PR adds correct mapping for decay field that goes between 0 - 10 000 000