### PR TITLE
fix(ProposalDetail): do not append [COMPLETION]

### DIFF
--- a/src/pages/proposals/ProposalDetail.vue
+++ b/src/pages/proposals/ProposalDetail.vue
@@ -1525,7 +1525,7 @@ export default {
     async onQuestPayout() {
       try {
         await this.createQuestPayout({
-          title: `${this.proposal.details_title_s} [COMPLETION]`,
+          title: this.proposal.details_title_s,
           description: 'test',
           questStartId: this.proposal.docId
         })


### PR DESCRIPTION
When trying to complete quests with a title longer than 50 characters, the smart-contract rejects the call.